### PR TITLE
Implement linearization

### DIFF
--- a/lang/axcut/examples/midi.rs
+++ b/lang/axcut/examples/midi.rs
@@ -1,0 +1,316 @@
+use axcut::pre_syntax::*;
+use axcut::syntax::{BinOp, ContextBinding, Polarity, Return, Ty, TypeDeclaration, XtorSig};
+
+use std::rc::Rc;
+
+fn main() {
+    let ty_list = TypeDeclaration {
+        name: "List".to_string(),
+        xtors: vec![
+            XtorSig {
+                name: "Nil".to_string(),
+                args: vec![],
+            },
+            XtorSig {
+                name: "Cons".to_string(),
+                args: vec![
+                    ContextBinding {
+                        var: "xs".to_string(),
+                        pol: Polarity::Prd,
+                        ty: Ty::Decl("List".to_string()),
+                    },
+                    ContextBinding {
+                        var: "x".to_string(),
+                        pol: Polarity::Ext,
+                        ty: Ty::Int,
+                    },
+                ],
+            },
+        ],
+    };
+
+    let ty_cont_list = TypeDeclaration {
+        name: "ContList".to_string(),
+        xtors: vec![XtorSig {
+            name: "Retl".to_string(),
+            args: vec![ContextBinding {
+                var: "kl".to_string(),
+                pol: Polarity::Prd,
+                ty: Ty::Decl("List".to_string()),
+            }],
+        }],
+    };
+
+    let ty_cont_int = TypeDeclaration {
+        name: "ContInt".to_string(),
+        xtors: vec![XtorSig {
+            name: "Reti".to_string(),
+            args: vec![ContextBinding {
+                var: "ki".to_string(),
+                pol: Polarity::Ext,
+                ty: Ty::Int,
+            }],
+        }],
+    };
+
+    let main_body = Statement::New(New {
+        var: "t".to_string(),
+        ty: Ty::Decl("ContInt".to_string()),
+        clauses: vec![Clause {
+            env: vec![ContextBinding {
+                var: "r".to_string(),
+                pol: Polarity::Ext,
+                ty: Ty::Int,
+            }],
+            case: Rc::new(Statement::Return(Return {
+                var: "r".to_string(),
+            })),
+        }],
+        next: Rc::new(Statement::New(New {
+            var: "k".to_string(),
+            ty: Ty::Decl("ContList".to_string()),
+            clauses: vec![Clause {
+                env: vec![ContextBinding {
+                    var: "as".to_string(),
+                    pol: Polarity::Prd,
+                    ty: Ty::Decl("List".to_string()),
+                }],
+                case: Rc::new(Statement::Call(Call {
+                    label: "sum".to_string(),
+                    args: vec![
+                        ContextBinding {
+                            var: "t".to_string(),
+                            pol: Polarity::Cns,
+                            ty: Ty::Decl("ContInt".to_string()),
+                        },
+                        ContextBinding {
+                            var: "as".to_string(),
+                            pol: Polarity::Prd,
+                            ty: Ty::Decl("List".to_string()),
+                        },
+                    ],
+                })),
+            }],
+            next: Rc::new(Statement::Leta(Leta {
+                var: "zs".to_string(),
+                ty: Ty::Decl("List".to_string()),
+                tag: "Nil".to_string(),
+                args: vec![],
+                next: Rc::new(Statement::Literal(Literal {
+                    lit: 3,
+                    var: "n".to_string(),
+                    case: Rc::new(Statement::Call(Call {
+                        label: "range".to_string(),
+                        args: vec![
+                            ContextBinding {
+                                var: "k".to_string(),
+                                pol: Polarity::Cns,
+                                ty: Ty::Decl("ContList".to_string()),
+                            },
+                            ContextBinding {
+                                var: "zs".to_string(),
+                                pol: Polarity::Prd,
+                                ty: Ty::Decl("List".to_string()),
+                            },
+                            ContextBinding {
+                                var: "n".to_string(),
+                                pol: Polarity::Ext,
+                                ty: Ty::Int,
+                            },
+                        ],
+                    })),
+                })),
+            })),
+        })),
+    });
+    let main = Def {
+        name: "main".to_string(),
+        context: Vec::new(),
+        body: main_body,
+    };
+
+    let range_body = Statement::IfZ(IfZ {
+        ifc: "i".to_string(),
+        thenc: Rc::new(Statement::Invoke(Invoke {
+            var: "k".to_string(),
+            tag: "Retl".to_string(),
+            ty: Ty::Decl("ContList".to_string()),
+            args: vec![ContextBinding {
+                var: "xs".to_string(),
+                pol: Polarity::Prd,
+                ty: Ty::Decl("List".to_string()),
+            }],
+        })),
+        elsec: Rc::new(Statement::Leta(Leta {
+            var: "ys".to_string(),
+            ty: Ty::Decl("List".to_string()),
+            tag: "Cons".to_string(),
+            args: vec![
+                ContextBinding {
+                    var: "xs".to_string(),
+                    pol: Polarity::Prd,
+                    ty: Ty::Decl("List".to_string()),
+                },
+                ContextBinding {
+                    var: "i".to_string(),
+                    pol: Polarity::Ext,
+                    ty: Ty::Int,
+                },
+            ],
+            next: Rc::new(Statement::Literal(Literal {
+                lit: -1,
+                var: "o".to_string(),
+                case: Rc::new(Statement::Op(Op {
+                    fst: "i".to_string(),
+                    op: BinOp::Sum,
+                    snd: "o".to_string(),
+                    var: "j".to_string(),
+                    case: Rc::new(Statement::Call(Call {
+                        label: "range".to_string(),
+                        args: vec![
+                            ContextBinding {
+                                var: "k".to_string(),
+                                pol: Polarity::Cns,
+                                ty: Ty::Decl("ContList".to_string()),
+                            },
+                            ContextBinding {
+                                var: "ys".to_string(),
+                                pol: Polarity::Prd,
+                                ty: Ty::Decl("List".to_string()),
+                            },
+                            ContextBinding {
+                                var: "j".to_string(),
+                                pol: Polarity::Ext,
+                                ty: Ty::Int,
+                            },
+                        ],
+                    })),
+                })),
+            })),
+        })),
+    });
+    let range = Def {
+        name: "range".to_string(),
+        context: vec![
+            ContextBinding {
+                var: "k".to_string(),
+                pol: Polarity::Cns,
+                ty: Ty::Decl("ContList".to_string()),
+            },
+            ContextBinding {
+                var: "xs".to_string(),
+                pol: Polarity::Prd,
+                ty: Ty::Decl("List".to_string()),
+            },
+            ContextBinding {
+                var: "i".to_string(),
+                pol: Polarity::Ext,
+                ty: Ty::Int,
+            },
+        ],
+        body: range_body,
+    };
+
+    let sum_body = Statement::Switch(Switch {
+        var: "xs".to_string(),
+        ty: Ty::Decl("List".to_string()),
+        clauses: vec![
+            Clause {
+                env: vec![],
+                case: Rc::new(Statement::Literal(Literal {
+                    lit: 0,
+                    var: "z".to_string(),
+                    case: Rc::new(Statement::Invoke(Invoke {
+                        var: "k".to_string(),
+                        tag: "Reti".to_string(),
+                        ty: Ty::Decl("ContInt".to_string()),
+                        args: vec![ContextBinding {
+                            var: "z".to_string(),
+                            pol: Polarity::Ext,
+                            ty: Ty::Int,
+                        }],
+                    })),
+                })),
+            },
+            Clause {
+                env: vec![
+                    ContextBinding {
+                        var: "ys".to_string(),
+                        pol: Polarity::Prd,
+                        ty: Ty::Decl("List".to_string()),
+                    },
+                    ContextBinding {
+                        var: "y".to_string(),
+                        pol: Polarity::Ext,
+                        ty: Ty::Int,
+                    },
+                ],
+                case: Rc::new(Statement::New(New {
+                    var: "j".to_string(),
+                    ty: Ty::Decl("ContInt".to_string()),
+                    clauses: vec![Clause {
+                        env: vec![ContextBinding {
+                            var: "r".to_string(),
+                            pol: Polarity::Ext,
+                            ty: Ty::Int,
+                        }],
+                        case: Rc::new(Statement::Op(Op {
+                            fst: "y".to_string(),
+                            op: BinOp::Sum,
+                            snd: "r".to_string(),
+                            var: "s".to_string(),
+                            case: Rc::new(Statement::Invoke(Invoke {
+                                var: "k".to_string(),
+                                tag: "Reti".to_string(),
+                                ty: Ty::Decl("ContInt".to_string()),
+                                args: vec![ContextBinding {
+                                    var: "s".to_string(),
+                                    pol: Polarity::Ext,
+                                    ty: Ty::Int,
+                                }],
+                            })),
+                        })),
+                    }],
+                    next: Rc::new(Statement::Call(Call {
+                        label: "sum".to_string(),
+                        args: vec![
+                            ContextBinding {
+                                var: "j".to_string(),
+                                pol: Polarity::Cns,
+                                ty: Ty::Decl("ContInt".to_string()),
+                            },
+                            ContextBinding {
+                                var: "ys".to_string(),
+                                pol: Polarity::Prd,
+                                ty: Ty::Decl("List".to_string()),
+                            },
+                        ],
+                    })),
+                })),
+            },
+        ],
+    });
+    let sum = Def {
+        name: "sum".to_string(),
+        context: vec![
+            ContextBinding {
+                var: "k".to_string(),
+                pol: Polarity::Cns,
+                ty: Ty::Decl("ContList".to_string()),
+            },
+            ContextBinding {
+                var: "xs".to_string(),
+                pol: Polarity::Prd,
+                ty: Ty::Decl("List".to_string()),
+            },
+        ],
+        body: sum_body,
+    };
+
+    let program = Prog {
+        defs: vec![main, range, sum],
+        types: vec![ty_list, ty_cont_list, ty_cont_int],
+    };
+
+    println!("{}", program::linearize(program))
+}

--- a/lang/axcut/examples/nonLinear.rs
+++ b/lang/axcut/examples/nonLinear.rs
@@ -1,0 +1,195 @@
+use axcut::pre_syntax::*;
+use axcut::syntax::{BinOp, ContextBinding, Polarity, Return, Ty, TypeDeclaration, XtorSig};
+
+use std::rc::Rc;
+
+fn main() {
+    let ty_box = TypeDeclaration {
+        name: "Box".to_string(),
+        xtors: vec![XtorSig {
+            name: "B".to_string(),
+            args: vec![ContextBinding {
+                var: "b".to_string(),
+                pol: Polarity::Ext,
+                ty: Ty::Int,
+            }],
+        }],
+    };
+    let ty_box_box = TypeDeclaration {
+        name: "BoxBox".to_string(),
+        xtors: vec![XtorSig {
+            name: "BB".to_string(),
+            args: vec![ContextBinding {
+                var: "bb".to_string(),
+                pol: Polarity::Prd,
+                ty: Ty::Decl("Box".to_string()),
+            }],
+        }],
+    };
+
+    let main_body_switch_switch = Statement::Switch(Switch {
+        var: "a2".to_string(),
+        ty: Ty::Decl("Box".to_string()),
+        clauses: vec![Clause {
+            env: vec![ContextBinding {
+                var: "y2".to_string(),
+                pol: Polarity::Ext,
+                ty: Ty::Int,
+            }],
+            case: Rc::new(Statement::Switch(Switch {
+                var: "a1".to_string(),
+                ty: Ty::Decl("Box".to_string()),
+                clauses: vec![Clause {
+                    env: vec![ContextBinding {
+                        var: "y1".to_string(),
+                        pol: Polarity::Ext,
+                        ty: Ty::Int,
+                    }],
+                    case: Rc::new(Statement::Op(Op {
+                        fst: "y1".to_string(),
+                        op: BinOp::Sum,
+                        snd: "y2".to_string(),
+                        var: "res".to_string(),
+                        case: Rc::new(Statement::Return(Return {
+                            var: "res".to_string(),
+                        })),
+                    })),
+                }],
+            })),
+        }],
+    });
+    let main_body_switch = Statement::Switch(Switch {
+        var: "bb".to_string(),
+        ty: Ty::Decl("BoxBox".to_string()),
+        clauses: vec![Clause {
+            env: vec![ContextBinding {
+                var: "b1".to_string(),
+                pol: Polarity::Prd,
+                ty: Ty::Decl("Box".to_string()),
+            }],
+            case: Rc::new(Statement::Switch(Switch {
+                var: "b1".to_string(),
+                ty: Ty::Decl("Box".to_string()),
+                clauses: vec![Clause {
+                    env: vec![ContextBinding {
+                        var: "x1".to_string(),
+                        pol: Polarity::Ext,
+                        ty: Ty::Int,
+                    }],
+                    case: Rc::new(Statement::Leta(Leta {
+                        var: "d1".to_string(),
+                        ty: Ty::Decl("Box".to_string()),
+                        tag: "B".to_string(),
+                        args: vec![ContextBinding {
+                            var: "x1".to_string(),
+                            pol: Polarity::Ext,
+                            ty: Ty::Int,
+                        }],
+                        next: Rc::new(Statement::Leta(Leta {
+                            var: "dd1".to_string(),
+                            ty: Ty::Decl("BoxBox".to_string()),
+                            tag: "BB".to_string(),
+                            args: vec![ContextBinding {
+                                var: "d1".to_string(),
+                                pol: Polarity::Prd,
+                                ty: Ty::Decl("Box".to_string()),
+                            }],
+                            next: Rc::new(Statement::Literal(Literal {
+                                lit: 4,
+                                var: "y".to_string(),
+                                case: Rc::new(Statement::Leta(Leta {
+                                    var: "a1".to_string(),
+                                    ty: Ty::Decl("Box".to_string()),
+                                    tag: "B".to_string(),
+                                    args: vec![ContextBinding {
+                                        var: "y".to_string(),
+                                        pol: Polarity::Ext,
+                                        ty: Ty::Int,
+                                    }],
+                                    next: Rc::new(Statement::Switch(Switch {
+                                        var: "bb".to_string(),
+                                        ty: Ty::Decl("BoxBox".to_string()),
+                                        clauses: vec![Clause {
+                                            env: vec![ContextBinding {
+                                                var: "b2".to_string(),
+                                                pol: Polarity::Prd,
+                                                ty: Ty::Decl("Box".to_string()),
+                                            }],
+                                            case: Rc::new(Statement::Switch(Switch {
+                                                var: "b2".to_string(),
+                                                ty: Ty::Decl("Box".to_string()),
+                                                clauses: vec![Clause {
+                                                    env: vec![ContextBinding {
+                                                        var: "x2".to_string(),
+                                                        pol: Polarity::Ext,
+                                                        ty: Ty::Int,
+                                                    }],
+                                                    case: Rc::new(Statement::Leta(Leta {
+                                                        var: "a2".to_string(),
+                                                        ty: Ty::Decl("Box".to_string()),
+                                                        tag: "B".to_string(),
+                                                        args: vec![ContextBinding {
+                                                            var: "x2".to_string(),
+                                                            pol: Polarity::Ext,
+                                                            ty: Ty::Int,
+                                                        }],
+                                                        next: Rc::new(main_body_switch_switch),
+                                                    })),
+                                                }],
+                                            })),
+                                        }],
+                                    })),
+                                })),
+                            })),
+                        })),
+                    })),
+                }],
+            })),
+        }],
+    });
+    let main_body = Statement::Literal(Literal {
+        lit: 3,
+        var: "f1".to_string(),
+        case: Rc::new(Statement::Literal(Literal {
+            lit: 3,
+            var: "f2".to_string(),
+            case: Rc::new(Statement::Literal(Literal {
+                lit: 3,
+                var: "x".to_string(),
+                case: Rc::new(Statement::Leta(Leta {
+                    var: "b".to_string(),
+                    ty: Ty::Decl("Box".to_string()),
+                    tag: "B".to_string(),
+                    args: vec![ContextBinding {
+                        var: "x".to_string(),
+                        pol: Polarity::Ext,
+                        ty: Ty::Int,
+                    }],
+                    next: Rc::new(Statement::Leta(Leta {
+                        var: "bb".to_string(),
+                        ty: Ty::Decl("BoxBox".to_string()),
+                        tag: "BB".to_string(),
+                        args: vec![ContextBinding {
+                            var: "b".to_string(),
+                            pol: Polarity::Prd,
+                            ty: Ty::Decl("Box".to_string()),
+                        }],
+                        next: Rc::new(main_body_switch),
+                    })),
+                })),
+            })),
+        })),
+    });
+    let main = Def {
+        name: "main".to_string(),
+        context: Vec::new(),
+        body: main_body,
+    };
+
+    let program = Prog {
+        defs: vec![main],
+        types: vec![ty_box, ty_box_box],
+    };
+
+    println!("{}", program::linearize(program))
+}

--- a/lang/axcut/src/lib.rs
+++ b/lang/axcut/src/lib.rs
@@ -1,1 +1,3 @@
+pub mod pre_syntax;
 pub mod syntax;
+pub mod traits;

--- a/lang/axcut/src/pre_syntax/call.rs
+++ b/lang/axcut/src/pre_syntax/call.rs
@@ -1,0 +1,62 @@
+use super::Statement;
+use crate::syntax::context::freshen;
+use crate::syntax::{stringify_and_join, Name, TypingContext, Var};
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::Linearizing;
+use crate::traits::substitution::Subst;
+
+use std::collections::HashSet;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Call {
+    pub label: Name,
+    pub args: TypingContext,
+}
+
+impl std::fmt::Display for Call {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let args = stringify_and_join(&self.args, ", ");
+        write!(f, "jump {}({})", self.label, args)
+    }
+}
+
+impl From<Call> for Statement {
+    fn from(value: Call) -> Self {
+        Statement::Call(value)
+    }
+}
+
+impl FreeVars for Call {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        self.args.free_vars(vars)
+    }
+}
+
+impl Subst for Call {
+    type Target = Call;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Call {
+        Call {
+            label: self.label,
+            args: self.args.subst_sim(subst),
+        }
+    }
+}
+
+impl Linearizing for Call {
+    type Target = crate::syntax::Substitute;
+    fn linearize(
+        self,
+        _context: TypingContext,
+        used_vars: &mut HashSet<Var>,
+    ) -> crate::syntax::Substitute {
+        let freshened_context = freshen(self.args.clone(), used_vars);
+        let rearrange = freshened_context.into_iter().zip(self.args).collect();
+        crate::syntax::Substitute {
+            rearrange,
+            next: Rc::new(crate::syntax::Call { label: self.label }.into()),
+        }
+    }
+}

--- a/lang/axcut/src/pre_syntax/clause.rs
+++ b/lang/axcut/src/pre_syntax/clause.rs
@@ -1,0 +1,51 @@
+use super::statement::Statement;
+use crate::syntax::{stringify_and_join, TypingContext, Var};
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::UsedBinders;
+use crate::traits::substitution::Subst;
+
+use std::collections::HashSet;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Clause {
+    pub env: TypingContext,
+    pub case: Rc<Statement>,
+}
+
+impl std::fmt::Display for Clause {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let env = stringify_and_join(&self.env, ", ");
+        write!(f, "({}) =>\n  {}", env, self.case)
+    }
+}
+
+impl FreeVars for Clause {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        self.case.free_vars(vars);
+        for binding in &self.env {
+            vars.remove(&binding.var);
+        }
+    }
+}
+
+impl Subst for Clause {
+    type Target = Clause;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Clause {
+        Clause {
+            case: self.case.subst_sim(subst),
+            ..self
+        }
+    }
+}
+
+impl UsedBinders for Clause {
+    fn used_binders(&self, used: &mut HashSet<Var>) {
+        for binding in &self.env {
+            used.insert(binding.var.clone());
+        }
+        self.case.used_binders(used);
+    }
+}

--- a/lang/axcut/src/pre_syntax/def.rs
+++ b/lang/axcut/src/pre_syntax/def.rs
@@ -1,0 +1,31 @@
+use super::Statement;
+use crate::syntax::{stringify_and_join, Name, TypingContext, Var};
+use crate::traits::linearize::Linearizing;
+
+use std::collections::HashSet;
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct Def {
+    pub name: Name,
+    pub context: TypingContext,
+    pub body: Statement,
+}
+
+impl std::fmt::Display for Def {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let args = stringify_and_join(&self.context, ", ");
+        write!(f, "def {}({}) :=\n  {}", self.name, args, self.body)
+    }
+}
+
+impl Linearizing for Def {
+    type Target = crate::syntax::Def;
+    fn linearize(self, context: TypingContext, used_vars: &mut HashSet<Var>) -> crate::syntax::Def {
+        crate::syntax::Def {
+            name: self.name,
+            context: self.context,
+            body: self.body.linearize(context, used_vars),
+        }
+    }
+}

--- a/lang/axcut/src/pre_syntax/ifz.rs
+++ b/lang/axcut/src/pre_syntax/ifz.rs
@@ -1,0 +1,69 @@
+use super::Statement;
+use crate::syntax::{TypingContext, Var};
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::{Linearizing, UsedBinders};
+use crate::traits::substitution::Subst;
+
+use std::collections::HashSet;
+use std::{fmt, rc::Rc};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IfZ {
+    pub ifc: Var,
+    pub thenc: Rc<Statement>,
+    pub elsec: Rc<Statement>,
+}
+
+impl std::fmt::Display for IfZ {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ifz {} {{\n    () =>\n  {}\n    () =>\n  {} }}",
+            self.ifc, self.thenc, self.elsec
+        )
+    }
+}
+
+impl From<IfZ> for Statement {
+    fn from(value: IfZ) -> Self {
+        Statement::IfZ(value)
+    }
+}
+
+impl FreeVars for IfZ {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        self.thenc.free_vars(vars);
+        self.elsec.free_vars(vars);
+        vars.insert(self.ifc.clone());
+    }
+}
+
+impl Subst for IfZ {
+    type Target = IfZ;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> IfZ {
+        IfZ {
+            ifc: self.ifc.subst_sim(subst),
+            thenc: self.thenc.subst_sim(subst),
+            elsec: self.elsec.subst_sim(subst),
+        }
+    }
+}
+
+impl UsedBinders for IfZ {
+    fn used_binders(&self, used: &mut HashSet<Var>) {
+        self.thenc.used_binders(used);
+        self.elsec.used_binders(used);
+    }
+}
+
+impl Linearizing for IfZ {
+    type Target = crate::syntax::IfZ;
+    fn linearize(self, context: TypingContext, used_vars: &mut HashSet<Var>) -> crate::syntax::IfZ {
+        crate::syntax::IfZ {
+            ifc: self.ifc,
+            thenc: self.thenc.linearize(context.clone(), used_vars),
+            elsec: self.elsec.linearize(context, used_vars),
+        }
+    }
+}

--- a/lang/axcut/src/pre_syntax/invoke.rs
+++ b/lang/axcut/src/pre_syntax/invoke.rs
@@ -1,0 +1,84 @@
+use super::Statement;
+use crate::syntax::context::freshen;
+use crate::syntax::{stringify_and_join, ContextBinding, Name, Polarity, Ty, TypingContext, Var};
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::Linearizing;
+use crate::traits::substitution::Subst;
+
+use std::collections::HashSet;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Invoke {
+    pub var: Var,
+    pub tag: Name,
+    pub ty: Ty,
+    pub args: TypingContext,
+}
+
+impl std::fmt::Display for Invoke {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let args = stringify_and_join(&self.args, ", ");
+        writeln!(f, "invoke {} {}({})", self.var, self.tag, args)
+    }
+}
+
+impl From<Invoke> for Statement {
+    fn from(value: Invoke) -> Self {
+        Statement::Invoke(value)
+    }
+}
+
+impl FreeVars for Invoke {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        self.args.free_vars(vars);
+        vars.insert(self.var.clone());
+    }
+}
+
+impl Subst for Invoke {
+    type Target = Invoke;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Invoke {
+        Invoke {
+            var: self.var.subst_sim(subst),
+            args: self.args.subst_sim(subst),
+            ..self
+        }
+    }
+}
+
+impl Linearizing for Invoke {
+    type Target = crate::syntax::Substitute;
+    fn linearize(
+        self,
+        _context: TypingContext,
+        used_vars: &mut HashSet<Var>,
+    ) -> crate::syntax::Substitute {
+        let freshened_context = freshen(self.args.clone(), used_vars);
+
+        let mut rearrange: Vec<(ContextBinding, ContextBinding)> =
+            freshened_context.into_iter().zip(self.args).collect();
+
+        let object_binding = ContextBinding {
+            var: self.var.clone(),
+            pol: Polarity::Cns,
+            ty: self.ty.clone(),
+        };
+
+        rearrange.push((object_binding.clone(), object_binding));
+
+        crate::syntax::Substitute {
+            rearrange,
+            next: Rc::new(
+                crate::syntax::Invoke {
+                    var: self.var,
+                    tag: self.tag,
+                    ty: self.ty,
+                }
+                .into(),
+            ),
+        }
+    }
+}

--- a/lang/axcut/src/pre_syntax/leta.rs
+++ b/lang/axcut/src/pre_syntax/leta.rs
@@ -1,0 +1,108 @@
+use super::statement::Statement;
+use crate::syntax::context::{filter_by_set, freshen};
+use crate::syntax::{stringify_and_join, ContextBinding, Name, Polarity, Ty, TypingContext, Var};
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::{Linearizing, UsedBinders};
+use crate::traits::substitution::Subst;
+
+use std::collections::HashSet;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Leta {
+    pub var: Var,
+    pub ty: Ty,
+    pub tag: Name,
+    pub args: TypingContext,
+    pub next: Rc<Statement>,
+}
+
+impl std::fmt::Display for Leta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let args = stringify_and_join(&self.args, ", ");
+        write!(
+            f,
+            "leta {} : {} = {}({});\n  {}",
+            self.var, self.ty, self.tag, args, self.next
+        )
+    }
+}
+
+impl From<Leta> for Statement {
+    fn from(value: Leta) -> Self {
+        Statement::Leta(value)
+    }
+}
+
+impl FreeVars for Leta {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        self.next.free_vars(vars);
+        vars.remove(&self.var);
+        self.args.free_vars(vars);
+    }
+}
+
+impl Subst for Leta {
+    type Target = Leta;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Leta {
+        Leta {
+            args: self.args.subst_sim(subst),
+            next: self.next.subst_sim(subst),
+            ..self
+        }
+    }
+}
+
+impl UsedBinders for Leta {
+    fn used_binders(&self, used: &mut HashSet<Var>) {
+        used.insert(self.var.clone());
+        self.next.used_binders(used);
+    }
+}
+
+impl Linearizing for Leta {
+    type Target = crate::syntax::Substitute;
+    fn linearize(
+        mut self,
+        context: TypingContext,
+        used_vars: &mut HashSet<Var>,
+    ) -> crate::syntax::Substitute {
+        let mut free_vars = HashSet::new();
+        self.next.free_vars(&mut free_vars);
+
+        let mut new_context = filter_by_set(&context, &free_vars);
+        let freshened_context = freshen(self.args.clone(), used_vars);
+
+        let mut full_context = new_context.clone();
+        full_context.append(&mut self.args);
+        let mut full_context_freshened = new_context.clone();
+        full_context_freshened.append(&mut freshened_context.clone());
+
+        let rearrange = full_context_freshened
+            .into_iter()
+            .zip(full_context)
+            .collect();
+
+        new_context.push(ContextBinding {
+            var: self.var.clone(),
+            pol: Polarity::Prd,
+            ty: self.ty.clone(),
+        });
+
+        crate::syntax::Substitute {
+            rearrange,
+            next: Rc::new(
+                crate::syntax::Leta {
+                    var: self.var,
+                    ty: self.ty,
+                    tag: self.tag,
+                    args: freshened_context,
+                    next: self.next.linearize(new_context, used_vars),
+                }
+                .into(),
+            ),
+        }
+    }
+}

--- a/lang/axcut/src/pre_syntax/literal.rs
+++ b/lang/axcut/src/pre_syntax/literal.rs
@@ -1,0 +1,92 @@
+use super::Statement;
+use crate::syntax::context::filter_by_set;
+use crate::syntax::{ContextBinding, Polarity, Ty, TypingContext, Var};
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::{Linearizing, UsedBinders};
+use crate::traits::substitution::Subst;
+
+use std::collections::HashSet;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Literal {
+    pub lit: i64,
+    pub var: Var,
+    pub case: Rc<Statement>,
+}
+
+impl std::fmt::Display for Literal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "lit {} <- {};\n  {}", self.var, self.lit, self.case)
+    }
+}
+
+impl From<Literal> for Statement {
+    fn from(value: Literal) -> Self {
+        Statement::Literal(value)
+    }
+}
+
+impl FreeVars for Literal {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        self.case.free_vars(vars);
+        vars.remove(&self.var);
+    }
+}
+
+impl Subst for Literal {
+    type Target = Literal;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Literal {
+        Literal {
+            case: self.case.subst_sim(subst),
+            ..self
+        }
+    }
+}
+
+impl UsedBinders for Literal {
+    fn used_binders(&self, used: &mut HashSet<Var>) {
+        used.insert(self.var.clone());
+        self.case.used_binders(used);
+    }
+}
+
+impl Linearizing for Literal {
+    type Target = crate::syntax::Substitute;
+    fn linearize(
+        self,
+        context: TypingContext,
+        used_vars: &mut HashSet<Var>,
+    ) -> crate::syntax::Substitute {
+        let mut free_vars = HashSet::new();
+        self.case.free_vars(&mut free_vars);
+
+        let mut new_context = filter_by_set(&context, &free_vars);
+
+        let rearrange = new_context
+            .clone()
+            .into_iter()
+            .zip(new_context.clone())
+            .collect();
+
+        new_context.push(ContextBinding {
+            var: self.var.clone(),
+            pol: Polarity::Ext,
+            ty: Ty::Int,
+        });
+
+        crate::syntax::Substitute {
+            rearrange,
+            next: Rc::new(
+                crate::syntax::Literal {
+                    lit: self.lit,
+                    var: self.var,
+                    case: self.case.linearize(new_context, used_vars),
+                }
+                .into(),
+            ),
+        }
+    }
+}

--- a/lang/axcut/src/pre_syntax/mod.rs
+++ b/lang/axcut/src/pre_syntax/mod.rs
@@ -1,0 +1,25 @@
+pub mod call;
+pub mod clause;
+pub mod def;
+pub mod ifz;
+pub mod invoke;
+pub mod leta;
+pub mod literal;
+pub mod new;
+pub mod op;
+pub mod program;
+pub mod statement;
+pub mod switch;
+
+pub use call::Call;
+pub use clause::Clause;
+pub use def::Def;
+pub use ifz::IfZ;
+pub use invoke::Invoke;
+pub use leta::Leta;
+pub use literal::Literal;
+pub use new::New;
+pub use op::Op;
+pub use program::Prog;
+pub use statement::Statement;
+pub use switch::Switch;

--- a/lang/axcut/src/pre_syntax/new.rs
+++ b/lang/axcut/src/pre_syntax/new.rs
@@ -1,0 +1,130 @@
+use super::{Clause, Statement};
+use crate::syntax::context::{context_vars, filter_by_set, freshen};
+use crate::syntax::{stringify_and_join, ContextBinding, Polarity, Ty, TypingContext, Var};
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::{Linearizing, UsedBinders};
+use crate::traits::substitution::Subst;
+
+use std::collections::HashSet;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct New {
+    pub var: Var,
+    pub ty: Ty,
+    pub clauses: Vec<Clause>,
+    pub next: Rc<Statement>,
+}
+
+impl std::fmt::Display for New {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let clauses = stringify_and_join(&self.clauses, "\n    ");
+        write!(
+            f,
+            "new {} : {} = {{\n    {} }};\n  {}",
+            self.var, self.ty, clauses, self.next
+        )
+    }
+}
+
+impl From<New> for Statement {
+    fn from(value: New) -> Self {
+        Statement::New(value)
+    }
+}
+
+impl FreeVars for New {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        self.next.free_vars(vars);
+        vars.remove(&self.var);
+        self.clauses.free_vars(vars);
+    }
+}
+
+impl Subst for New {
+    type Target = New;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> New {
+        New {
+            clauses: self.clauses.subst_sim(subst),
+            next: self.next.subst_sim(subst),
+            ..self
+        }
+    }
+}
+
+impl UsedBinders for New {
+    fn used_binders(&self, used: &mut HashSet<Var>) {
+        used.insert(self.var.clone());
+        self.clauses.used_binders(used);
+        self.next.used_binders(used);
+    }
+}
+
+impl Linearizing for New {
+    type Target = crate::syntax::Substitute;
+    fn linearize(
+        self,
+        context: TypingContext,
+        used_vars: &mut HashSet<Var>,
+    ) -> crate::syntax::Substitute {
+        let mut free_vars_clauses = HashSet::new();
+        self.clauses.free_vars(&mut free_vars_clauses);
+        let mut free_vars_next = HashSet::new();
+        self.next.free_vars(&mut free_vars_next);
+
+        let context_clauses = filter_by_set(&context, &free_vars_clauses);
+        let context_next = filter_by_set(&context, &free_vars_next);
+        let mut context_next_freshened = freshen(context_next.clone(), used_vars);
+
+        let mut full_context_freshened = context_next_freshened.clone();
+        full_context_freshened.append(&mut context_clauses.clone());
+        let mut full_context = context_next.clone();
+        full_context.append(&mut context_clauses.clone());
+
+        let rearrange = full_context_freshened
+            .into_iter()
+            .zip(full_context)
+            .collect();
+
+        let substitution_next: Vec<(Var, Var)> = context_vars(&context_next)
+            .into_iter()
+            .zip(context_vars(&context_next_freshened))
+            .collect();
+        let next_substituted = self.next.subst_sim(substitution_next.as_slice());
+
+        context_next_freshened.push(ContextBinding {
+            var: self.var.clone(),
+            pol: Polarity::Cns,
+            ty: self.ty.clone(),
+        });
+
+        let clauses = self
+            .clauses
+            .into_iter()
+            .map(|Clause { env, case }| {
+                let mut extended_context = env.clone();
+                extended_context.append(&mut context_clauses.clone());
+                crate::syntax::Clause {
+                    env,
+                    case: case.linearize(extended_context, used_vars),
+                }
+            })
+            .collect();
+
+        crate::syntax::Substitute {
+            rearrange,
+            next: Rc::new(
+                crate::syntax::New {
+                    var: self.var,
+                    ty: self.ty,
+                    env: context_clauses,
+                    clauses,
+                    next: next_substituted.linearize(context_next_freshened, used_vars),
+                }
+                .into(),
+            ),
+        }
+    }
+}

--- a/lang/axcut/src/pre_syntax/op.rs
+++ b/lang/axcut/src/pre_syntax/op.rs
@@ -1,0 +1,106 @@
+use super::Statement;
+use crate::syntax::context::filter_by_set;
+use crate::syntax::{BinOp, ContextBinding, Polarity, Ty, TypingContext, Var};
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::{Linearizing, UsedBinders};
+use crate::traits::substitution::Subst;
+
+use std::collections::HashSet;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Op {
+    pub fst: Var,
+    pub op: BinOp,
+    pub snd: Var,
+    pub var: Var,
+    pub case: Rc<Statement>,
+}
+
+impl std::fmt::Display for Op {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} <- {} {} {};\n  {}",
+            self.var, self.fst, self.op, self.snd, self.case
+        )
+    }
+}
+
+impl From<Op> for Statement {
+    fn from(value: Op) -> Self {
+        Statement::Op(value)
+    }
+}
+
+impl FreeVars for Op {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        self.case.free_vars(vars);
+        vars.remove(&self.var);
+        vars.insert(self.fst.clone());
+        vars.insert(self.snd.clone());
+    }
+}
+
+impl Subst for Op {
+    type Target = Op;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Op {
+        Op {
+            fst: self.fst.subst_sim(subst),
+            snd: self.snd.subst_sim(subst),
+            case: self.case.subst_sim(subst),
+            ..self
+        }
+    }
+}
+
+impl UsedBinders for Op {
+    fn used_binders(&self, used: &mut HashSet<Var>) {
+        used.insert(self.var.clone());
+        self.case.used_binders(used);
+    }
+}
+
+impl Linearizing for Op {
+    type Target = crate::syntax::Substitute;
+    fn linearize(
+        self,
+        context: TypingContext,
+        used_vars: &mut HashSet<Var>,
+    ) -> crate::syntax::Substitute {
+        let mut free_vars = HashSet::new();
+        self.case.free_vars(&mut free_vars);
+        free_vars.insert(self.fst.clone());
+        free_vars.insert(self.snd.clone());
+
+        let mut new_context = filter_by_set(&context, &free_vars);
+
+        let rearrange = new_context
+            .clone()
+            .into_iter()
+            .zip(new_context.clone())
+            .collect();
+
+        new_context.push(ContextBinding {
+            var: self.var.clone(),
+            pol: Polarity::Ext,
+            ty: Ty::Int,
+        });
+
+        crate::syntax::Substitute {
+            rearrange,
+            next: Rc::new(
+                crate::syntax::Op {
+                    fst: self.fst,
+                    op: self.op,
+                    snd: self.snd,
+                    var: self.var,
+                    case: self.case.linearize(new_context, used_vars),
+                }
+                .into(),
+            ),
+        }
+    }
+}

--- a/lang/axcut/src/pre_syntax/program.rs
+++ b/lang/axcut/src/pre_syntax/program.rs
@@ -1,0 +1,39 @@
+use super::Def;
+use crate::syntax::{stringify_and_join, TypeDeclaration};
+use crate::traits::linearize::{Linearizing, UsedBinders};
+
+use std::collections::HashSet;
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct Prog {
+    pub defs: Vec<Def>,
+    pub types: Vec<TypeDeclaration>,
+}
+
+impl fmt::Display for Prog {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let types_joined: String = stringify_and_join(&self.types, "\n");
+        let defs_joined: String = stringify_and_join(&self.defs, "\n\n");
+        write!(f, "{defs_joined}\n{types_joined}")
+    }
+}
+
+pub fn linearize(program: Prog) -> crate::syntax::Prog {
+    crate::syntax::Prog {
+        defs: program
+            .defs
+            .into_iter()
+            .map(|def| {
+                let context = def.context.clone();
+                let mut used_vars = HashSet::new();
+                def.body.used_binders(&mut used_vars);
+                for binding in &context {
+                    used_vars.insert(binding.var.clone());
+                }
+                def.linearize(context, &mut used_vars)
+            })
+            .collect(),
+        types: program.types,
+    }
+}

--- a/lang/axcut/src/pre_syntax/statement.rs
+++ b/lang/axcut/src/pre_syntax/statement.rs
@@ -1,0 +1,115 @@
+use super::{Call, IfZ, Invoke, Leta, Literal, New, Op, Switch};
+use crate::syntax::{Return, TypingContext, Var};
+
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::{Linearizing, UsedBinders};
+use crate::traits::substitution::Subst;
+
+use std::collections::HashSet;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Statement {
+    Call(Call),
+    Leta(Leta),
+    Switch(Switch),
+    New(New),
+    Invoke(Invoke),
+    Literal(Literal),
+    Op(Op),
+    IfZ(IfZ),
+    Return(Return),
+    Done,
+}
+
+impl std::fmt::Display for Statement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Statement::Call(j) => j.fmt(f),
+            Statement::Leta(l) => l.fmt(f),
+            Statement::Switch(s) => s.fmt(f),
+            Statement::New(n) => n.fmt(f),
+            Statement::Invoke(i) => i.fmt(f),
+            Statement::Literal(n) => n.fmt(f),
+            Statement::Op(o) => o.fmt(f),
+            Statement::IfZ(i) => i.fmt(f),
+            Statement::Return(r) => r.fmt(f),
+            Statement::Done => write!(f, "Done"),
+        }
+    }
+}
+
+impl FreeVars for Statement {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        match self {
+            Statement::Call(c) => c.free_vars(vars),
+            Statement::Leta(l) => l.free_vars(vars),
+            Statement::Switch(s) => s.free_vars(vars),
+            Statement::New(n) => n.free_vars(vars),
+            Statement::Invoke(i) => i.free_vars(vars),
+            Statement::Literal(n) => n.free_vars(vars),
+            Statement::Op(o) => o.free_vars(vars),
+            Statement::IfZ(i) => i.free_vars(vars),
+            Statement::Return(Return { var }) => {
+                vars.insert(var.clone());
+            }
+            Statement::Done => {}
+        }
+    }
+}
+
+impl Subst for Statement {
+    type Target = Statement;
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Statement {
+        match self {
+            Statement::Call(c) => c.subst_sim(subst).into(),
+            Statement::Leta(l) => l.subst_sim(subst).into(),
+            Statement::Switch(s) => s.subst_sim(subst).into(),
+            Statement::New(n) => n.subst_sim(subst).into(),
+            Statement::Invoke(i) => i.subst_sim(subst).into(),
+            Statement::Literal(n) => n.subst_sim(subst).into(),
+            Statement::Op(o) => o.subst_sim(subst).into(),
+            Statement::IfZ(i) => i.subst_sim(subst).into(),
+            Statement::Return(Return { var }) => Statement::Return(Return {
+                var: var.subst_sim(subst),
+            }),
+            Statement::Done => Statement::Done,
+        }
+    }
+}
+
+impl UsedBinders for Statement {
+    fn used_binders(&self, used: &mut HashSet<Var>) {
+        match self {
+            Statement::Leta(l) => l.used_binders(used),
+            Statement::Switch(s) => s.used_binders(used),
+            Statement::New(n) => n.used_binders(used),
+            Statement::Literal(n) => n.used_binders(used),
+            Statement::Op(o) => o.used_binders(used),
+            Statement::IfZ(i) => i.used_binders(used),
+            _ => {}
+        }
+    }
+}
+
+impl Linearizing for Statement {
+    type Target = crate::syntax::Statement;
+    fn linearize(
+        self,
+        context: TypingContext,
+        used_vars: &mut HashSet<Var>,
+    ) -> crate::syntax::Statement {
+        match self {
+            Statement::Call(j) => j.linearize(context, used_vars).into(),
+            Statement::Leta(l) => l.linearize(context, used_vars).into(),
+            Statement::Switch(s) => s.linearize(context, used_vars).into(),
+            Statement::New(n) => n.linearize(context, used_vars).into(),
+            Statement::Invoke(i) => i.linearize(context, used_vars).into(),
+            Statement::Literal(n) => n.linearize(context, used_vars).into(),
+            Statement::Op(o) => o.linearize(context, used_vars).into(),
+            Statement::IfZ(i) => i.linearize(context, used_vars).into(),
+            Statement::Return(Return { var }) => Return { var }.into(),
+            Statement::Done => crate::syntax::Statement::Done,
+        }
+    }
+}

--- a/lang/axcut/src/pre_syntax/switch.rs
+++ b/lang/axcut/src/pre_syntax/switch.rs
@@ -1,0 +1,113 @@
+use super::{Clause, Statement};
+use crate::syntax::context::filter_by_set;
+use crate::syntax::{stringify_and_join, ContextBinding, Polarity, Ty, TypingContext, Var};
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::{fresh_var, Linearizing, UsedBinders};
+use crate::traits::substitution::Subst;
+
+use std::collections::HashSet;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Switch {
+    pub var: Var,
+    pub ty: Ty,
+    pub clauses: Vec<Clause>,
+}
+
+impl std::fmt::Display for Switch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let clauses = stringify_and_join(&self.clauses, "\n    ");
+        write!(f, "switch {} {{\n    {} }}", self.var, clauses)
+    }
+}
+
+impl From<Switch> for Statement {
+    fn from(value: Switch) -> Self {
+        Statement::Switch(value)
+    }
+}
+
+impl FreeVars for Switch {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        self.clauses.free_vars(vars);
+        vars.insert(self.var.clone());
+    }
+}
+
+impl Subst for Switch {
+    type Target = Switch;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Switch {
+        Switch {
+            var: self.var.subst_sim(subst),
+            clauses: self.clauses.subst_sim(subst),
+            ..self
+        }
+    }
+}
+
+impl UsedBinders for Switch {
+    fn used_binders(&self, used: &mut HashSet<Var>) {
+        self.clauses.used_binders(used)
+    }
+}
+
+impl Linearizing for Switch {
+    type Target = crate::syntax::Substitute;
+    fn linearize(
+        self,
+        context: TypingContext,
+        used_vars: &mut HashSet<Var>,
+    ) -> crate::syntax::Substitute {
+        let mut free_vars = HashSet::new();
+        self.clauses.free_vars(&mut free_vars);
+
+        let fresh_var = fresh_var(used_vars, &self.var);
+        used_vars.insert(fresh_var.clone());
+
+        let new_context = filter_by_set(&context, &free_vars);
+        let mut full_context = new_context.clone();
+        full_context.push(ContextBinding {
+            var: self.var,
+            pol: Polarity::Prd,
+            ty: self.ty.clone(),
+        });
+        let mut full_context_freshened = new_context.clone();
+        full_context_freshened.push(ContextBinding {
+            var: fresh_var.clone(),
+            pol: Polarity::Prd,
+            ty: self.ty.clone(),
+        });
+
+        let rearrange = full_context_freshened
+            .into_iter()
+            .zip(full_context)
+            .collect();
+
+        let clauses = self
+            .clauses
+            .into_iter()
+            .map(|Clause { env, case }| {
+                let mut extended_context = new_context.clone();
+                extended_context.append(&mut env.clone());
+                crate::syntax::Clause {
+                    env,
+                    case: case.linearize(extended_context, used_vars),
+                }
+            })
+            .collect();
+
+        crate::syntax::Substitute {
+            rearrange,
+            next: Rc::new(
+                crate::syntax::Switch {
+                    var: fresh_var,
+                    clauses,
+                }
+                .into(),
+            ),
+        }
+    }
+}

--- a/lang/axcut/src/syntax/context.rs
+++ b/lang/axcut/src/syntax/context.rs
@@ -1,5 +1,9 @@
 use super::{names::Var, polarity::Polarity, types::Ty};
+use crate::traits::free_vars::FreeVars;
+use crate::traits::linearize::fresh_var;
+use crate::traits::substitution::Subst;
 
+use std::collections::HashSet;
 use std::fmt;
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
@@ -15,4 +19,71 @@ impl fmt::Display for ContextBinding {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} :{}: {}", self.var, self.pol, self.ty)
     }
+}
+
+impl FreeVars for ContextBinding {
+    fn free_vars(&self, vars: &mut HashSet<Var>) {
+        vars.insert(self.var.clone());
+    }
+}
+
+impl Subst for ContextBinding {
+    type Target = ContextBinding;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> ContextBinding {
+        ContextBinding {
+            var: self.var.subst_sim(subst),
+            ..self
+        }
+    }
+}
+
+/// Picks fresh names for all variables, which could be avoided by also passing the context with
+/// which the variables that are not allowed to clash.
+pub fn freshen(context: TypingContext, used_vars: &mut HashSet<Var>) -> TypingContext {
+    let mut new_context = Vec::with_capacity(context.len());
+    for binding in context {
+        let new_var = fresh_var(used_vars, &binding.var);
+        used_vars.insert(new_var.clone());
+        new_context.push(ContextBinding {
+            var: new_var,
+            ..binding
+        });
+    }
+    new_context
+}
+
+/// Only keeps the binding in `context` which are contained in `set`, but tries to retain the
+/// positions of as many bindings as possible.
+#[must_use]
+pub fn filter_by_set(context: &TypingContext, set: &HashSet<Var>) -> TypingContext {
+    let mut new_context = context.clone();
+    for (pos, binding) in context.iter().enumerate() {
+        if pos >= new_context.len() {
+            break;
+        } else if !set.contains(&binding.var) {
+            let mut found_element = false;
+            while new_context.len() - 1 > pos {
+                if set.contains(&new_context[new_context.len() - 1].var) {
+                    found_element = true;
+                    new_context.swap_remove(pos);
+                    break;
+                }
+                new_context.pop();
+            }
+            if !found_element {
+                new_context.pop();
+            }
+        }
+    }
+    new_context
+}
+
+#[must_use]
+pub fn context_vars(context: &TypingContext) -> Vec<Var> {
+    let mut vars = Vec::with_capacity(context.len());
+    for binding in context {
+        vars.push(binding.var.clone());
+    }
+    vars
 }

--- a/lang/axcut/src/syntax/declaration.rs
+++ b/lang/axcut/src/syntax/declaration.rs
@@ -1,4 +1,4 @@
-use super::{context::TypingContext, names::Name, stringify_and_join};
+use super::{stringify_and_join, Name, TypingContext};
 use std::fmt;
 
 #[derive(Debug, Clone)]

--- a/lang/axcut/src/syntax/mod.rs
+++ b/lang/axcut/src/syntax/mod.rs
@@ -40,9 +40,9 @@ pub use types::Ty;
 
 use std::fmt;
 
-fn stringify_and_join<T: fmt::Display>(vec: &[T], separator: &str) -> String {
+pub fn stringify_and_join<T: fmt::Display>(vec: &[T], separator: &str) -> String {
     vec.iter()
-        .map(|x| x.to_string())
+        .map(ToString::to_string)
         .collect::<Vec<String>>()
         .join(separator)
 }

--- a/lang/axcut/src/syntax/names.rs
+++ b/lang/axcut/src/syntax/names.rs
@@ -1,7 +1,20 @@
+use crate::traits::substitution::Subst;
+
 use std::fmt;
 
 pub type Name = String;
 pub type Var = String;
+
+impl Subst for Var {
+    type Target = Var;
+
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Var {
+        match subst.iter().find(|(old, _)| *old == self) {
+            None => self,
+            Some((_, new)) => new.clone(),
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BinOp {

--- a/lang/axcut/src/syntax/ret.rs
+++ b/lang/axcut/src/syntax/ret.rs
@@ -1,4 +1,5 @@
 use super::names::Var;
+use super::statement::Statement;
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9,5 +10,11 @@ pub struct Return {
 impl std::fmt::Display for Return {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "return {}", self.var)
+    }
+}
+
+impl From<Return> for Statement {
+    fn from(value: Return) -> Self {
+        Statement::Return(value)
     }
 }

--- a/lang/axcut/src/traits/free_vars.rs
+++ b/lang/axcut/src/traits/free_vars.rs
@@ -1,0 +1,16 @@
+use std::collections::HashSet;
+
+use crate::syntax::Var;
+
+/// Computing the free variables of a statement.
+pub trait FreeVars {
+    fn free_vars(&self, vars: &mut HashSet<Var>);
+}
+
+impl<T: FreeVars> FreeVars for Vec<T> {
+    fn free_vars(self: &Vec<T>, vars: &mut HashSet<Var>) {
+        for element in self {
+            element.free_vars(vars);
+        }
+    }
+}

--- a/lang/axcut/src/traits/linearize.rs
+++ b/lang/axcut/src/traits/linearize.rs
@@ -1,0 +1,43 @@
+use crate::syntax::{TypingContext, Var};
+
+use std::collections::HashSet;
+use std::rc::Rc;
+
+pub trait UsedBinders {
+    fn used_binders(&self, used: &mut HashSet<Var>);
+}
+
+impl<T: UsedBinders> UsedBinders for Vec<T> {
+    fn used_binders(&self, used: &mut HashSet<Var>) {
+        for element in self {
+            element.used_binders(used);
+        }
+    }
+}
+
+#[must_use]
+pub fn fresh_var(used_vars: &HashSet<Var>, base_name: &str) -> Var {
+    fresh_var_n(used_vars, base_name, 0)
+}
+
+fn fresh_var_n(used_vars: &HashSet<Var>, base_name: &str, mut n: i32) -> Var {
+    let mut new_var: Var = format!("{base_name}{n}");
+    while used_vars.contains(&new_var) {
+        n += 1;
+        new_var = format!("{base_name}{n}");
+    }
+    new_var
+}
+
+/// This assumes all variable bindings to be unique and maintains this invariant.
+pub trait Linearizing {
+    type Target;
+    fn linearize(self, context: TypingContext, used_vars: &mut HashSet<Var>) -> Self::Target;
+}
+
+impl<T: Linearizing + Clone> Linearizing for Rc<T> {
+    type Target = Rc<T::Target>;
+    fn linearize(self, context: TypingContext, used_vars: &mut HashSet<Var>) -> Self::Target {
+        Rc::new(Rc::unwrap_or_clone(self).linearize(context, used_vars))
+    }
+}

--- a/lang/axcut/src/traits/mod.rs
+++ b/lang/axcut/src/traits/mod.rs
@@ -1,0 +1,3 @@
+pub mod free_vars;
+pub mod linearize;
+pub mod substitution;

--- a/lang/axcut/src/traits/substitution.rs
+++ b/lang/axcut/src/traits/substitution.rs
@@ -1,0 +1,26 @@
+use std::rc::Rc;
+
+use crate::syntax::Var;
+
+/// As all variable bindings are assumed to be unique, no care is needed to avoid captures or
+/// shadowing.
+pub trait Subst: Clone {
+    type Target;
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Self::Target;
+}
+
+impl<T: Subst> Subst for Rc<T> {
+    type Target = Rc<T::Target>;
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Self::Target {
+        Rc::new(Rc::unwrap_or_clone(self).subst_sim(subst))
+    }
+}
+
+impl<T: Subst> Subst for Vec<T> {
+    type Target = Vec<T::Target>;
+    fn subst_sim(self, subst: &[(Var, Var)]) -> Vec<T::Target> {
+        self.into_iter()
+            .map(|element| element.subst_sim(subst))
+            .collect()
+    }
+}


### PR DESCRIPTION
This implements the translation from a variation of AxCut which does not track linearity (in `axcut/src/pre_syntax` (we should find a better name)) to AxCut by inserting explicit substitutions and annotating closure environments.