### PR TITLE
Use fresh names based on previous ones where possible

### DIFF
--- a/lang/core/src/syntax/clause.rs
+++ b/lang/core/src/syntax/clause.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::traits::{
     focus::{Focusing, FocusingState},
-    free_vars::{fresh_covar, fresh_var, FreeV},
+    free_vars::{fresh_var, FreeV},
     substitution::Subst,
 };
 
@@ -83,11 +83,10 @@ impl Subst for Clause {
         let mut var_subst: Vec<(Term<Prd>, Var)> = vec![];
         let mut covar_subst: Vec<(Term<Cns>, Covar)> = vec![];
 
-        for old_bnd in self.context.iter() {
+        for old_bnd in &self.context {
             match old_bnd {
                 ContextBinding::VarBinding { var, ty } => {
-                    let new_var: Var = fresh_var(&free_vars);
-                    free_vars.insert(new_var.clone());
+                    let new_var: Var = fresh_var(&mut free_vars, var);
                     new_context.push(ContextBinding::VarBinding {
                         var: new_var.clone(),
                         ty: ty.clone(),
@@ -103,8 +102,7 @@ impl Subst for Clause {
                     ));
                 }
                 ContextBinding::CovarBinding { covar, ty } => {
-                    let new_covar: Covar = fresh_covar(&free_covars);
-                    free_covars.insert(new_covar.clone());
+                    let new_covar: Covar = fresh_var(&mut free_vars, covar);
                     new_context.push(ContextBinding::CovarBinding {
                         covar: new_covar.clone(),
                         ty: ty.clone(),

--- a/lang/core/src/syntax/program.rs
+++ b/lang/core/src/syntax/program.rs
@@ -178,9 +178,9 @@ pub fn transform_prog(prog: Prog) -> crate::syntax_var::Prog {
         defs: defs
             .into_iter()
             .map(|def| {
-                let mut state = state.clone();
-                state.used_vars = context_vars(&def.context);
-                state.used_covars = context_covars(&def.context);
+                let mut used_vars = context_vars(&def.context);
+                used_vars.extend(context_covars(&def.context));
+                state.used_vars = used_vars;
                 def.focus(&mut state)
             })
             .collect(),

--- a/lang/core/src/syntax/statement/cut.rs
+++ b/lang/core/src/syntax/statement/cut.rs
@@ -64,6 +64,12 @@ impl Print for Cut {
     }
 }
 
+impl From<Cut> for Statement {
+    fn from(value: Cut) -> Self {
+        Statement::Cut(value)
+    }
+}
+
 impl FreeV for Cut {
     fn free_vars(&self) -> HashSet<Var> {
         let Cut {
@@ -85,12 +91,6 @@ impl FreeV for Cut {
         let mut free_covars = producer.free_covars();
         free_covars.extend(consumer.free_covars());
         free_covars
-    }
-}
-
-impl From<Cut> for Statement {
-    fn from(value: Cut) -> Self {
-        Statement::Cut(value)
     }
 }
 

--- a/lang/core/src/syntax/statement/op.rs
+++ b/lang/core/src/syntax/statement/op.rs
@@ -53,6 +53,12 @@ impl Print for Op {
     }
 }
 
+impl From<Op> for Statement {
+    fn from(value: Op) -> Self {
+        Statement::Op(value)
+    }
+}
+
 impl FreeV for Op {
     fn free_vars(&self) -> HashSet<Var> {
         let mut free_vars = self.fst.free_vars();
@@ -66,12 +72,6 @@ impl FreeV for Op {
         free_covars.extend(self.snd.free_covars());
         free_covars.extend(self.continuation.free_covars());
         free_covars
-    }
-}
-
-impl From<Op> for Statement {
-    fn from(value: Op) -> Self {
-        Statement::Op(value)
     }
 }
 

--- a/lang/core/src/syntax/term/xcase.rs
+++ b/lang/core/src/syntax/term/xcase.rs
@@ -295,7 +295,7 @@ mod tests {
                             ty: Ty::Int(),
                         },
                         ContextBinding::VarBinding {
-                            var: "x1".to_owned(),
+                            var: "xs0".to_owned(),
                             ty: Ty::Decl("ListInt".to_owned()),
                         },
                         ContextBinding::CovarBinding {

--- a/lang/core/src/traits/focus.rs
+++ b/lang/core/src/traits/focus.rs
@@ -5,7 +5,7 @@ use crate::{
         substitution::SubstitutionBinding,
         Covar, Var,
     },
-    traits::free_vars::{fresh_covar, fresh_var},
+    traits::free_vars::fresh_var,
 };
 
 use std::collections::{HashSet, VecDeque};
@@ -14,31 +14,26 @@ use std::rc::Rc;
 #[derive(Default, Clone)]
 pub struct FocusingState<'a> {
     pub used_vars: HashSet<Var>,
-    pub used_covars: HashSet<Covar>,
     pub codata_types: &'a [CodataDeclaration],
 }
 
 impl FocusingState<'_> {
     pub fn fresh_var(&mut self) -> Var {
-        let new_var = fresh_var(&self.used_vars);
-        self.used_vars.insert(new_var.clone());
-        new_var
+        fresh_var(&mut self.used_vars, "x")
     }
 
     pub fn fresh_covar(&mut self) -> Covar {
-        let new_covar = fresh_covar(&self.used_covars);
-        self.used_covars.insert(new_covar.clone());
-        new_covar
+        fresh_var(&mut self.used_vars, "a")
     }
 
     pub fn add_context(&mut self, context: &TypingContext) {
-        for binding in context.iter() {
+        for binding in context {
             match binding {
                 ContextBinding::VarBinding { var, ty: _ } => {
                     self.used_vars.insert(var.clone());
                 }
                 ContextBinding::CovarBinding { covar, ty: _ } => {
-                    self.used_covars.insert(covar.clone());
+                    self.used_vars.insert(covar.clone());
                 }
             }
         }

--- a/lang/core/src/traits/free_vars.rs
+++ b/lang/core/src/traits/free_vars.rs
@@ -25,30 +25,16 @@ impl<T: FreeV> FreeV for Vec<T> {
     }
 }
 
-pub fn fresh_var(xs: &HashSet<Var>) -> Var {
-    fresh_var_n(xs, 0)
-}
-
-fn fresh_var_n(xs: &HashSet<Var>, mut n: i32) -> Var {
-    let mut new_var: Var = format!("x{}", n);
-    while xs.contains(&new_var) {
+#[must_use]
+pub fn fresh_var(used_vars: &mut HashSet<Var>, base_name: &str) -> Var {
+    let mut n = 0;
+    let mut new_var: Var = format!("{base_name}{n}");
+    while used_vars.contains(&new_var) {
         n += 1;
-        new_var = format!("x{}", n);
+        new_var = format!("{base_name}{n}");
     }
+    used_vars.insert(new_var.clone());
     new_var
-}
-
-pub fn fresh_covar(xs: &HashSet<Covar>) -> Covar {
-    fresh_covar_n(xs, 0)
-}
-
-fn fresh_covar_n(xs: &HashSet<Covar>, mut n: i32) -> Covar {
-    let mut new_covar: Covar = format!("a{}", n);
-    while xs.contains(&new_covar) {
-        n += 1;
-        new_covar = format!("a{}", n);
-    }
-    new_covar
 }
 
 #[cfg(test)]

--- a/lang/fun2core/src/definition.rs
+++ b/lang/fun2core/src/definition.rs
@@ -2,7 +2,7 @@ use core::syntax::{
     term::{Cns, Prd},
     types::Ty,
 };
-use core::traits::free_vars::fresh_covar;
+use core::traits::free_vars::fresh_var;
 use fun::syntax::Covariable;
 use std::{collections::HashSet, rc::Rc};
 
@@ -12,10 +12,8 @@ pub struct CompileState {
 }
 
 impl CompileState {
-    pub fn free_covar_from_state(&mut self) -> Covariable {
-        let new_covar: Covariable = fresh_covar(&self.covars);
-        self.covars.insert(new_covar.clone());
-        new_covar
+    pub fn fresh_covar(&mut self) -> Covariable {
+        fresh_var(&mut self.covars, "a")
     }
 }
 
@@ -56,7 +54,7 @@ pub trait CompileWithCont: Sized {
     ///
     /// In comments we write `〚t〛` for `compile_opt`.
     fn compile_opt(self, state: &mut CompileState, ty: Ty) -> core::syntax::term::Term<Prd> {
-        let new_covar = state.free_covar_from_state();
+        let new_covar = state.fresh_covar();
         let new_statement = self.compile_with_cont(
             core::syntax::term::XVar {
                 prdcns: core::syntax::term::Cns,

--- a/lang/fun2core/src/program.rs
+++ b/lang/fun2core/src/program.rs
@@ -3,7 +3,7 @@
 use crate::definition::{CompileState, CompileWithCont};
 use core::syntax::context::context_covars;
 use core::syntax::term::Cns;
-use core::traits::free_vars::fresh_covar;
+use core::traits::free_vars::fresh_var;
 use fun::syntax::types::OptTyped;
 
 pub fn compile_subst(
@@ -69,7 +69,7 @@ pub fn compile_def(def: fun::syntax::declarations::Definition) -> core::syntax::
     let mut initial_state: CompileState = CompileState {
         covars: context_covars(&new_context).into_iter().collect(),
     };
-    let new_covar = initial_state.free_covar_from_state();
+    let new_covar = initial_state.fresh_covar();
     let ty = compile_ty(
         def.body
             .get_type()
@@ -111,7 +111,7 @@ pub fn compile_dtor(
 ) -> core::syntax::declaration::XtorSig<core::syntax::declaration::Codata> {
     let mut new_args = compile_context(dtor.args);
 
-    let new_cv = fresh_covar(&context_covars(&new_args).into_iter().collect());
+    let new_cv = fresh_var(&mut context_covars(&new_args).into_iter().collect(), "a");
 
     new_args.push(core::syntax::context::ContextBinding::CovarBinding {
         covar: new_cv,

--- a/lang/fun2core/src/terms/cocase.rs
+++ b/lang/fun2core/src/terms/cocase.rs
@@ -55,7 +55,7 @@ fn compile_clause(
     clause: fun::syntax::terms::Clause<fun::syntax::Name>,
     state: &mut CompileState,
 ) -> core::syntax::Clause {
-    let new_cv = state.free_covar_from_state();
+    let new_cv = state.fresh_covar();
     let ty = compile_ty(
         clause
             .get_type()

--- a/lang/fun2core/src/terms/fun_call.rs
+++ b/lang/fun2core/src/terms/fun_call.rs
@@ -34,7 +34,7 @@ impl CompileWithCont for fun::syntax::terms::Fun {
     fn compile_opt(self, state: &mut CompileState, ty: Ty) -> core::syntax::term::Term<Prd> {
         state.covars.extend(subst_covars(&self.args));
         // default implementation
-        let new_covar = state.free_covar_from_state();
+        let new_covar = state.fresh_covar();
         let var_ty = compile_ty(
             self.ret_ty
                 .clone()


### PR DESCRIPTION
This picks fresh names based on old ones where appropriate and simplifies the focusing state a bit. This is also in preparation for the coming pass to make all names unique.