### PR TITLE
Change names for integer continuation type to get valid tokens

### DIFF
--- a/lang/core/src/syntax_var/declaration.rs
+++ b/lang/core/src/syntax_var/declaration.rs
@@ -17,9 +17,9 @@ pub struct TypeDeclaration {
 #[must_use]
 pub fn cont_int() -> TypeDeclaration {
     TypeDeclaration {
-        name: "0Cont".to_string(),
+        name: "_Cont".to_string(),
         xtors: vec![XtorSig {
-            name: "0Ret".to_string(),
+            name: "_Ret".to_string(),
             args: vec![ContextBinding {
                 var: "x".to_string(),
                 chi: Chirality::Prd,


### PR DESCRIPTION
I think it should be fine to use `_Cont` and `_Ret` as assembler tokens to resolve #68. @BinderDavid can you check on aarch64?