### PR TITLE
Leave out trivial substitutions in linearization

### DIFF
--- a/lang/axcut/src/syntax/statements/call.rs
+++ b/lang/axcut/src/syntax/statements/call.rs
@@ -57,19 +57,24 @@ impl Subst for Call {
 }
 
 impl Linearizing for Call {
-    type Target = Substitute;
-    fn linearize(self, _context: Vec<Var>, used_vars: &mut HashSet<Var>) -> Substitute {
-        let freshened_context = freshen(&self.args, HashSet::new(), used_vars);
-        let rearrange = freshened_context.into_iter().zip(self.args).collect();
-        Substitute {
-            rearrange,
-            next: Rc::new(
-                Call {
-                    label: self.label,
-                    args: vec![],
-                }
-                .into(),
-            ),
+    type Target = Statement;
+    fn linearize(self, context: Vec<Var>, used_vars: &mut HashSet<Var>) -> Statement {
+        let call = Call {
+            label: self.label,
+            args: vec![],
+        }
+        .into();
+
+        if context == self.args {
+            call
+        } else {
+            let freshened_context = freshen(&self.args, HashSet::new(), used_vars);
+            let rearrange = freshened_context.into_iter().zip(self.args).collect();
+            Substitute {
+                rearrange,
+                next: Rc::new(call),
+            }
+            .into()
         }
     }
 }

--- a/lang/axcut/src/syntax/statements/mod.rs
+++ b/lang/axcut/src/syntax/statements/mod.rs
@@ -119,13 +119,13 @@ impl Linearizing for Statement {
             Statement::Substitute(_) => {
                 panic!("Linearization should only be done on terms without explicit substitutions")
             }
-            Statement::Call(call) => call.linearize(context, used_vars).into(),
-            Statement::Leta(leta) => leta.linearize(context, used_vars).into(),
-            Statement::Switch(switch) => switch.linearize(context, used_vars).into(),
-            Statement::New(new) => new.linearize(context, used_vars).into(),
-            Statement::Invoke(invoke) => invoke.linearize(context, used_vars).into(),
-            Statement::Literal(lit) => lit.linearize(context, used_vars).into(),
-            Statement::Op(op) => op.linearize(context, used_vars).into(),
+            Statement::Call(call) => call.linearize(context, used_vars),
+            Statement::Leta(leta) => leta.linearize(context, used_vars),
+            Statement::Switch(switch) => switch.linearize(context, used_vars),
+            Statement::New(new) => new.linearize(context, used_vars),
+            Statement::Invoke(invoke) => invoke.linearize(context, used_vars),
+            Statement::Literal(lit) => lit.linearize(context, used_vars),
+            Statement::Op(op) => op.linearize(context, used_vars),
             Statement::IfE(ife) => ife.linearize(context, used_vars).into(),
             Statement::IfL(ifl) => ifl.linearize(context, used_vars).into(),
             Statement::IfZ(ifz) => ifz.linearize(context, used_vars).into(),


### PR DESCRIPTION
While there is no assembly code generted for trivial substitutions, it is better for the readability of linearized programs to leave them out in the first place.