### PR TITLE
Avoid administrative redexes for arithmetic operators in bind

### DIFF
--- a/examples/EraseUnused.sc
+++ b/examples/EraseUnused.sc
@@ -1,9 +1,6 @@
 data ListInt { Nil, Cons(x: Int, xs: ListInt) }
 
-//def useless(i: Int, n: Int, b: ListInt): Int := ifl(i, n, useless(i + 1, n, replicate(0, i, Nil)), i);
-//def replicate(v: Int, n: Int, a: ListInt): ListInt := ifz(n, a, replicate(v, n - 1, Cons(v, a)));
-
-def useless(i: Int, n: Int, b: ListInt): Int := ifl(i, n, let j: Int = i + 1 in useless(j, n, replicate(0, i, Nil)),i);
-def replicate(v: Int, n: Int, a: ListInt): ListInt := ifz(n, a, let m: Int = n - 1 in replicate(v, m, Cons(v, a)));
+def useless(i: Int, n: Int, b: ListInt): Int := ifl(i, n, useless(i + 1, n, replicate(0, i, Nil)), i);
+def replicate(v: Int, n: Int, a: ListInt): ListInt := ifz(n, a, replicate(v, n - 1, Cons(v, a)));
 
 def main(n: Int): Int := useless(0, n, Nil);

--- a/examples/FactorialAccumulator.sc
+++ b/examples/FactorialAccumulator.sc
@@ -1,5 +1,3 @@
-//def factorial(a: Int, i: Int): Int := ifz(i, a, factorial(((i * a) - 1000000007), (i - 1)));
-
-def factorial(a: Int, i: Int): Int := ifz(i, a, let j: Int = i - 1 in let c: Int = i * a in let d: Int = c % 1000000007 in factorial(d, j));
+def factorial(a: Int, i: Int): Int := ifz(i, a, factorial(((i * a) % 1000000007), (i - 1)));
 
 def main(n: Int): Int := factorial(1, n);

--- a/examples/FibonacciRecursive.sc
+++ b/examples/FibonacciRecursive.sc
@@ -1,5 +1,3 @@
-//def fibonacci(i: Int): Int := ifz(i, i, ife(i, 1, i, (fibonacci(i - 1)) + (fibonacci(i - 2))));
-
-def fibonacci(i: Int): Int := ifz(i, i, ife(i, 1, i, let a: Int = i - 1 in let x: Int = fibonacci(a) in let b: Int = i - 2 in x + (fibonacci(b))));
+def fibonacci(i: Int): Int := ifz(i, i, ife(i, 1, i, (fibonacci(i - 1)) + (fibonacci(i - 2))));
 
 def main(n: Int): Int := fibonacci(n);

--- a/examples/IterateIncrement.sc
+++ b/examples/IterateIncrement.sc
@@ -1,7 +1,5 @@
 codata FunIntInt { Ap(x:Int) : Int }
 
-//def iterate(i: Int, f: FunIntInt, a: Int): Int := ifz(i, a, iterate(i - 1, f, f.Ap(a)));
-
-def iterate(i: Int, f: FunIntInt, a: Int): Int := ifz(i, a, let j: Int = i - 1 in iterate(j, f, f.Ap(a)));
+def iterate(i: Int, f: FunIntInt, a: Int): Int := ifz(i, a, iterate(i - 1, f, f.Ap(a)));
 
 def main(n: Int): Int := iterate(n, cocase { Ap(x: Int) => x + 1}, 0);

--- a/examples/Lists.sc
+++ b/examples/Lists.sc
@@ -19,4 +19,4 @@ def len(l : ListInt) : Int :=
     l.case { Nil => 0,
              Cons(x:Int,xs:ListInt) => 1 + (len(xs)) };
 
-def main() : Int := len(Cons(1, Cons(2, Cons(3, Cons(4, Nil)))));
+def main() : Int := len(Cons(1 + 2, Cons(2, Cons(3, Cons(4, Nil)))));

--- a/examples/LookupTree.sc
+++ b/examples/LookupTree.sc
@@ -1,11 +1,6 @@
 data TreeInt { Leaf(x: Int), Node(left: TreeInt, right: TreeInt) }
 
-//def create(i: Int, n: Int): TreeInt := ifl(i, n, let t: TreeInt = create(i + 1, n) in Node(t, t), Leaf(n));
-//
-//def lookup(t: TreeInt): Int := case t of { Leaf(v: Int) => v,
-//                                           Node(left: TreeInt, right: TreeInt) => lookup(left) };
-
-def create(i: Int, n: Int): TreeInt := ifl(i, n, let t: TreeInt = let j: Int = i + 1 in create(j, n) in Node(t, t), Leaf(n));
+def create(i: Int, n: Int): TreeInt := ifl(i, n, let t: TreeInt = create(i + 1, n) in Node(t, t), Leaf(n));
 
 def lookup(t: TreeInt): Int := t.case { Leaf(v: Int) => v,
                                         Node(left: TreeInt, right: TreeInt) => lookup(left) };

--- a/examples/MatchOptions.sc
+++ b/examples/MatchOptions.sc
@@ -1,13 +1,7 @@
 data OptionInt { None, Some(x: Int) }
 
-//def attempt(i: Int): OptionInt := ifz(i, Some(i), case attempt(i - 1) of { None => None,
-//                                                                           Some(x: Int) => Some(x + 1) });
-//
-//def main(n: Int): Int := case attempt(n) of { None => 0 - 1,
-//                                              Some(x: Int) => x };
+def attempt(i: Int): OptionInt := ifz(i, Some(i), (attempt(i - 1)).case { None => None,
+                                                                          Some(x: Int) => Some(x + 1) });
 
-def attempt(i: Int): OptionInt := ifz(i, Some(i), let j: Int = i - 1 in (attempt(j)).case { None => None,
-                                                                                            Some(x: Int) => let y: Int = x + 1 in Some(y) });
-
-def main(n: Int): Int := (attempt(n)).case { None => let r: Int = 0 - 1 in r,
+def main(n: Int): Int := (attempt(n)).case { None => 0 - 1,
                                              Some(x: Int) => x };

--- a/examples/SumRange.sc
+++ b/examples/SumRange.sc
@@ -1,13 +1,6 @@
 data ListInt { Nil, Cons(x: Int, xs: ListInt) }
 
-//def range(i: Int, n: Int): ListInt := ifl(i, n, Cons(i, range(i + 1, n)), Nil);
-//
-//def sum(xs: ListInt): Int := case xs of { Nil => 0,
-//                                          Cons(y: Int, ys: ListInt) => y + (sum(ys)) };
-//
-//def main(n: Int): Int := sum(range(0, n));
-
-def range(i: Int, n: Int): ListInt := ifl(i, n, Cons(i, let c: Int = i + 1 in range(c, n)), Nil);
+def range(i: Int, n: Int): ListInt := ifl(i, n, Cons(i, range(i + 1, n)), Nil);
 
 def sum(xs: ListInt): Int := xs.case { Nil => 0,
                                        Cons(y: Int, ys: ListInt) => y + (sum(ys)) };

--- a/lang/core/src/syntax/statement/op.rs
+++ b/lang/core/src/syntax/statement/op.rs
@@ -114,7 +114,7 @@ impl Uniquify for Op {
 
 impl Focusing for Op {
     type Target = crate::syntax_var::Statement;
-    ///N(⊙(p_1, p_2; s)) = bind(p_1)[λa1.bind(p_2)[λa_2.⊙ (a_1, a_2; N(s))]]
+    ///N(⊙ (p_1, p_2; c)) = bind(p_1)[λa1.bind(p_2)[λa_2.⊙ (a_1, a_2; N(c))]]
     fn focus(self, state: &mut FocusingState) -> crate::syntax_var::Statement {
         let cont = Box::new(|var_fst: Var, state: &mut FocusingState| {
             Rc::unwrap_or_clone(self.snd).bind(

--- a/lang/fun2core/src/terms/destructor.rs
+++ b/lang/fun2core/src/terms/destructor.rs
@@ -7,7 +7,7 @@ use fun::syntax::{substitution::subst_covars, types::OptTyped};
 
 impl CompileWithCont for fun::syntax::terms::Destructor {
     /// ```text
-    /// 〚t.D(t_1, ...) 〛_{c} = 〚t〛_{D(〚t_1〛, ...); c)}
+    /// 〚t.D(t_1, ...) 〛_{c} = 〚t〛_{D(〚t_1〛, ..., c)}
     /// ```
     fn compile_with_cont(
         self,
@@ -17,7 +17,7 @@ impl CompileWithCont for fun::syntax::terms::Destructor {
         state.covars.extend(subst_covars(&self.args));
         let mut args = compile_subst(self.args, state);
         args.push(core::syntax::substitution::SubstitutionBinding::ConsumerBinding(cont));
-        // new continuation: D(〚t_1〛, ...); c)
+        // new continuation: D(〚t_1〛, ..., c)
         let new_cont = core::syntax::term::Xtor {
             prdcns: Cns,
             id: self.id,


### PR DESCRIPTION
For arithmetic operators in argument positions, the current focusing transformation often generates critical pairs which are administrative and could be reduced immediately. The changes made here aim to prevent generating these administrative redexes by special-casing the `bind` function for producers of the form `mu a. op(p_1, p_2, a)`, inlining the continuation there.
This may affect #78.