### PR TITLE
Fix translation of let if bound term has codata type

### DIFF
--- a/lang/fun2core/src/definition.rs
+++ b/lang/fun2core/src/definition.rs
@@ -1,4 +1,5 @@
 use core::syntax::{
+    declaration::CodataDeclaration,
     term::{Cns, Prd},
     types::Ty,
 };
@@ -7,11 +8,12 @@ use fun::syntax::Covariable;
 use std::{collections::HashSet, rc::Rc};
 
 #[derive(Default)]
-pub struct CompileState {
+pub struct CompileState<'a> {
     pub covars: HashSet<Covariable>,
+    pub codata_types: &'a [CodataDeclaration],
 }
 
-impl CompileState {
+impl CompileState<'_> {
     pub fn fresh_covar(&mut self) -> Covariable {
         fresh_var(&mut self.covars, "a")
     }


### PR DESCRIPTION
In the translation of `let` in `Fun`, it is not sound to inline the continuation into the bound term if the latter has a codata type. This is because codata types follow CBN evaluation and inlining would force CBV evaluation instead. This PR hence distinguishes the case for codata.