### PR TITLE
Use all-caps for aarch64 instructions consistently

### DIFF
--- a/lang/axcut2aarch64/src/into_routine.rs
+++ b/lang/axcut2aarch64/src/into_routine.rs
@@ -30,21 +30,21 @@ asm_main7:
 _asm_main7:
 // setup
 // save registers
-str X16, [sp, -16]!
-str X17, [sp, -16]!
-str X18, [sp, -16]!
-str X19, [sp, -16]!
-str X20, [sp, -16]!
-str X21, [sp, -16]!
-str X22, [sp, -16]!
-str X23, [sp, -16]!
-str X24, [sp, -16]!
-str X25, [sp, -16]!
-str X26, [sp, -16]!
-str X27, [sp, -16]!
-str X28, [sp, -16]!
-str X29, [sp, -16]!
-str X30, [sp, -16]!\n";
+STR X16, [sp, -16]!
+STR X17, [sp, -16]!
+STR X18, [sp, -16]!
+STR X19, [sp, -16]!
+STR X20, [sp, -16]!
+STR X21, [sp, -16]!
+STR X22, [sp, -16]!
+STR X23, [sp, -16]!
+STR X24, [sp, -16]!
+STR X25, [sp, -16]!
+STR X26, [sp, -16]!
+STR X27, [sp, -16]!
+STR X28, [sp, -16]!
+STR X29, [sp, -16]!
+STR X30, [sp, -16]!\n";
 
     fn move_params(n: usize) -> String {
         match n {
@@ -78,22 +78,22 @@ str X30, [sp, -16]!\n";
 const CLEANUP: &str = "// cleanup
 cleanup:
 // restore registers
-ldr X30, [sp], 16
-ldr X29, [sp], 16
-ldr X28, [sp], 16
-ldr X27, [sp], 16
-ldr X26, [sp], 16
-ldr X25, [sp], 16
-ldr X24, [sp], 16
-ldr X23, [sp], 16
-ldr X22, [sp], 16
-ldr X21, [sp], 16
-ldr X20, [sp], 16
-ldr X19, [sp], 16
-ldr X18, [sp], 16
-ldr X17, [sp], 16
-ldr X16, [sp], 16
-ret";
+LDR X30, [sp], 16
+LDR X29, [sp], 16
+LDR X28, [sp], 16
+LDR X27, [sp], 16
+LDR X26, [sp], 16
+LDR X25, [sp], 16
+LDR X24, [sp], 16
+LDR X23, [sp], 16
+LDR X22, [sp], 16
+LDR X21, [sp], 16
+LDR X20, [sp], 16
+LDR X19, [sp], 16
+LDR X18, [sp], 16
+LDR X17, [sp], 16
+LDR X16, [sp], 16
+RET";
 
 #[allow(clippy::vec_init_then_push)]
 #[must_use]

--- a/lang/axcut2aarch64/tests/asm/arith.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/arith.aarch64.asm
@@ -25,21 +25,21 @@ asm_main7:
 _asm_main7:
 // setup
 // save registers
-str X16, [sp, -16]!
-str X17, [sp, -16]!
-str X18, [sp, -16]!
-str X19, [sp, -16]!
-str X20, [sp, -16]!
-str X21, [sp, -16]!
-str X22, [sp, -16]!
-str X23, [sp, -16]!
-str X24, [sp, -16]!
-str X25, [sp, -16]!
-str X26, [sp, -16]!
-str X27, [sp, -16]!
-str X28, [sp, -16]!
-str X29, [sp, -16]!
-str X30, [sp, -16]!
+STR X16, [sp, -16]!
+STR X17, [sp, -16]!
+STR X18, [sp, -16]!
+STR X19, [sp, -16]!
+STR X20, [sp, -16]!
+STR X21, [sp, -16]!
+STR X22, [sp, -16]!
+STR X23, [sp, -16]!
+STR X24, [sp, -16]!
+STR X25, [sp, -16]!
+STR X26, [sp, -16]!
+STR X27, [sp, -16]!
+STR X28, [sp, -16]!
+STR X29, [sp, -16]!
+STR X30, [sp, -16]!
 
 // move parameters into place
 
@@ -64,19 +64,19 @@ B cleanup
 // cleanup
 cleanup:
 // restore registers
-ldr X30, [sp], 16
-ldr X29, [sp], 16
-ldr X28, [sp], 16
-ldr X27, [sp], 16
-ldr X26, [sp], 16
-ldr X25, [sp], 16
-ldr X24, [sp], 16
-ldr X23, [sp], 16
-ldr X22, [sp], 16
-ldr X21, [sp], 16
-ldr X20, [sp], 16
-ldr X19, [sp], 16
-ldr X18, [sp], 16
-ldr X17, [sp], 16
-ldr X16, [sp], 16
-ret
+LDR X30, [sp], 16
+LDR X29, [sp], 16
+LDR X28, [sp], 16
+LDR X27, [sp], 16
+LDR X26, [sp], 16
+LDR X25, [sp], 16
+LDR X24, [sp], 16
+LDR X23, [sp], 16
+LDR X22, [sp], 16
+LDR X21, [sp], 16
+LDR X20, [sp], 16
+LDR X19, [sp], 16
+LDR X18, [sp], 16
+LDR X17, [sp], 16
+LDR X16, [sp], 16
+RET

--- a/lang/axcut2aarch64/tests/asm/closure.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/closure.aarch64.asm
@@ -25,21 +25,21 @@ asm_main7:
 _asm_main7:
 // setup
 // save registers
-str X16, [sp, -16]!
-str X17, [sp, -16]!
-str X18, [sp, -16]!
-str X19, [sp, -16]!
-str X20, [sp, -16]!
-str X21, [sp, -16]!
-str X22, [sp, -16]!
-str X23, [sp, -16]!
-str X24, [sp, -16]!
-str X25, [sp, -16]!
-str X26, [sp, -16]!
-str X27, [sp, -16]!
-str X28, [sp, -16]!
-str X29, [sp, -16]!
-str X30, [sp, -16]!
+STR X16, [sp, -16]!
+STR X17, [sp, -16]!
+STR X18, [sp, -16]!
+STR X19, [sp, -16]!
+STR X20, [sp, -16]!
+STR X21, [sp, -16]!
+STR X22, [sp, -16]!
+STR X23, [sp, -16]!
+STR X24, [sp, -16]!
+STR X25, [sp, -16]!
+STR X26, [sp, -16]!
+STR X27, [sp, -16]!
+STR X28, [sp, -16]!
+STR X29, [sp, -16]!
+STR X30, [sp, -16]!
 
 // move parameters into place
 
@@ -171,19 +171,19 @@ BR X6
 // cleanup
 cleanup:
 // restore registers
-ldr X30, [sp], 16
-ldr X29, [sp], 16
-ldr X28, [sp], 16
-ldr X27, [sp], 16
-ldr X26, [sp], 16
-ldr X25, [sp], 16
-ldr X24, [sp], 16
-ldr X23, [sp], 16
-ldr X22, [sp], 16
-ldr X21, [sp], 16
-ldr X20, [sp], 16
-ldr X19, [sp], 16
-ldr X18, [sp], 16
-ldr X17, [sp], 16
-ldr X16, [sp], 16
-ret
+LDR X30, [sp], 16
+LDR X29, [sp], 16
+LDR X28, [sp], 16
+LDR X27, [sp], 16
+LDR X26, [sp], 16
+LDR X25, [sp], 16
+LDR X24, [sp], 16
+LDR X23, [sp], 16
+LDR X22, [sp], 16
+LDR X21, [sp], 16
+LDR X20, [sp], 16
+LDR X19, [sp], 16
+LDR X18, [sp], 16
+LDR X17, [sp], 16
+LDR X16, [sp], 16
+RET

--- a/lang/axcut2aarch64/tests/asm/either.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/either.aarch64.asm
@@ -25,21 +25,21 @@ asm_main7:
 _asm_main7:
 // setup
 // save registers
-str X16, [sp, -16]!
-str X17, [sp, -16]!
-str X18, [sp, -16]!
-str X19, [sp, -16]!
-str X20, [sp, -16]!
-str X21, [sp, -16]!
-str X22, [sp, -16]!
-str X23, [sp, -16]!
-str X24, [sp, -16]!
-str X25, [sp, -16]!
-str X26, [sp, -16]!
-str X27, [sp, -16]!
-str X28, [sp, -16]!
-str X29, [sp, -16]!
-str X30, [sp, -16]!
+STR X16, [sp, -16]!
+STR X17, [sp, -16]!
+STR X18, [sp, -16]!
+STR X19, [sp, -16]!
+STR X20, [sp, -16]!
+STR X21, [sp, -16]!
+STR X22, [sp, -16]!
+STR X23, [sp, -16]!
+STR X24, [sp, -16]!
+STR X25, [sp, -16]!
+STR X26, [sp, -16]!
+STR X27, [sp, -16]!
+STR X28, [sp, -16]!
+STR X29, [sp, -16]!
+STR X30, [sp, -16]!
 
 // move parameters into place
 
@@ -180,19 +180,19 @@ B cleanup
 // cleanup
 cleanup:
 // restore registers
-ldr X30, [sp], 16
-ldr X29, [sp], 16
-ldr X28, [sp], 16
-ldr X27, [sp], 16
-ldr X26, [sp], 16
-ldr X25, [sp], 16
-ldr X24, [sp], 16
-ldr X23, [sp], 16
-ldr X22, [sp], 16
-ldr X21, [sp], 16
-ldr X20, [sp], 16
-ldr X19, [sp], 16
-ldr X18, [sp], 16
-ldr X17, [sp], 16
-ldr X16, [sp], 16
-ret
+LDR X30, [sp], 16
+LDR X29, [sp], 16
+LDR X28, [sp], 16
+LDR X27, [sp], 16
+LDR X26, [sp], 16
+LDR X25, [sp], 16
+LDR X24, [sp], 16
+LDR X23, [sp], 16
+LDR X22, [sp], 16
+LDR X21, [sp], 16
+LDR X20, [sp], 16
+LDR X19, [sp], 16
+LDR X18, [sp], 16
+LDR X17, [sp], 16
+LDR X16, [sp], 16
+RET

--- a/lang/axcut2aarch64/tests/asm/list.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/list.aarch64.asm
@@ -25,21 +25,21 @@ asm_main7:
 _asm_main7:
 // setup
 // save registers
-str X16, [sp, -16]!
-str X17, [sp, -16]!
-str X18, [sp, -16]!
-str X19, [sp, -16]!
-str X20, [sp, -16]!
-str X21, [sp, -16]!
-str X22, [sp, -16]!
-str X23, [sp, -16]!
-str X24, [sp, -16]!
-str X25, [sp, -16]!
-str X26, [sp, -16]!
-str X27, [sp, -16]!
-str X28, [sp, -16]!
-str X29, [sp, -16]!
-str X30, [sp, -16]!
+STR X16, [sp, -16]!
+STR X17, [sp, -16]!
+STR X18, [sp, -16]!
+STR X19, [sp, -16]!
+STR X20, [sp, -16]!
+STR X21, [sp, -16]!
+STR X22, [sp, -16]!
+STR X23, [sp, -16]!
+STR X24, [sp, -16]!
+STR X25, [sp, -16]!
+STR X26, [sp, -16]!
+STR X27, [sp, -16]!
+STR X28, [sp, -16]!
+STR X29, [sp, -16]!
+STR X30, [sp, -16]!
 
 // move parameters into place
 
@@ -343,19 +343,19 @@ B cleanup
 // cleanup
 cleanup:
 // restore registers
-ldr X30, [sp], 16
-ldr X29, [sp], 16
-ldr X28, [sp], 16
-ldr X27, [sp], 16
-ldr X26, [sp], 16
-ldr X25, [sp], 16
-ldr X24, [sp], 16
-ldr X23, [sp], 16
-ldr X22, [sp], 16
-ldr X21, [sp], 16
-ldr X20, [sp], 16
-ldr X19, [sp], 16
-ldr X18, [sp], 16
-ldr X17, [sp], 16
-ldr X16, [sp], 16
-ret
+LDR X30, [sp], 16
+LDR X29, [sp], 16
+LDR X28, [sp], 16
+LDR X27, [sp], 16
+LDR X26, [sp], 16
+LDR X25, [sp], 16
+LDR X24, [sp], 16
+LDR X23, [sp], 16
+LDR X22, [sp], 16
+LDR X21, [sp], 16
+LDR X20, [sp], 16
+LDR X19, [sp], 16
+LDR X18, [sp], 16
+LDR X17, [sp], 16
+LDR X16, [sp], 16
+RET

--- a/lang/axcut2aarch64/tests/asm/midi.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/midi.aarch64.asm
@@ -25,21 +25,21 @@ asm_main7:
 _asm_main7:
 // setup
 // save registers
-str X16, [sp, -16]!
-str X17, [sp, -16]!
-str X18, [sp, -16]!
-str X19, [sp, -16]!
-str X20, [sp, -16]!
-str X21, [sp, -16]!
-str X22, [sp, -16]!
-str X23, [sp, -16]!
-str X24, [sp, -16]!
-str X25, [sp, -16]!
-str X26, [sp, -16]!
-str X27, [sp, -16]!
-str X28, [sp, -16]!
-str X29, [sp, -16]!
-str X30, [sp, -16]!
+STR X16, [sp, -16]!
+STR X17, [sp, -16]!
+STR X18, [sp, -16]!
+STR X19, [sp, -16]!
+STR X20, [sp, -16]!
+STR X21, [sp, -16]!
+STR X22, [sp, -16]!
+STR X23, [sp, -16]!
+STR X24, [sp, -16]!
+STR X25, [sp, -16]!
+STR X26, [sp, -16]!
+STR X27, [sp, -16]!
+STR X28, [sp, -16]!
+STR X29, [sp, -16]!
+STR X30, [sp, -16]!
 
 // move parameters into place
 
@@ -461,19 +461,19 @@ BR X6
 // cleanup
 cleanup:
 // restore registers
-ldr X30, [sp], 16
-ldr X29, [sp], 16
-ldr X28, [sp], 16
-ldr X27, [sp], 16
-ldr X26, [sp], 16
-ldr X25, [sp], 16
-ldr X24, [sp], 16
-ldr X23, [sp], 16
-ldr X22, [sp], 16
-ldr X21, [sp], 16
-ldr X20, [sp], 16
-ldr X19, [sp], 16
-ldr X18, [sp], 16
-ldr X17, [sp], 16
-ldr X16, [sp], 16
-ret
+LDR X30, [sp], 16
+LDR X29, [sp], 16
+LDR X28, [sp], 16
+LDR X27, [sp], 16
+LDR X26, [sp], 16
+LDR X25, [sp], 16
+LDR X24, [sp], 16
+LDR X23, [sp], 16
+LDR X22, [sp], 16
+LDR X21, [sp], 16
+LDR X20, [sp], 16
+LDR X19, [sp], 16
+LDR X18, [sp], 16
+LDR X17, [sp], 16
+LDR X16, [sp], 16
+RET

--- a/lang/axcut2aarch64/tests/asm/mini.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/mini.aarch64.asm
@@ -25,21 +25,21 @@ asm_main7:
 _asm_main7:
 // setup
 // save registers
-str X16, [sp, -16]!
-str X17, [sp, -16]!
-str X18, [sp, -16]!
-str X19, [sp, -16]!
-str X20, [sp, -16]!
-str X21, [sp, -16]!
-str X22, [sp, -16]!
-str X23, [sp, -16]!
-str X24, [sp, -16]!
-str X25, [sp, -16]!
-str X26, [sp, -16]!
-str X27, [sp, -16]!
-str X28, [sp, -16]!
-str X29, [sp, -16]!
-str X30, [sp, -16]!
+STR X16, [sp, -16]!
+STR X17, [sp, -16]!
+STR X18, [sp, -16]!
+STR X19, [sp, -16]!
+STR X20, [sp, -16]!
+STR X21, [sp, -16]!
+STR X22, [sp, -16]!
+STR X23, [sp, -16]!
+STR X24, [sp, -16]!
+STR X25, [sp, -16]!
+STR X26, [sp, -16]!
+STR X27, [sp, -16]!
+STR X28, [sp, -16]!
+STR X29, [sp, -16]!
+STR X30, [sp, -16]!
 
 // move parameters into place
 
@@ -64,19 +64,19 @@ B cleanup
 // cleanup
 cleanup:
 // restore registers
-ldr X30, [sp], 16
-ldr X29, [sp], 16
-ldr X28, [sp], 16
-ldr X27, [sp], 16
-ldr X26, [sp], 16
-ldr X25, [sp], 16
-ldr X24, [sp], 16
-ldr X23, [sp], 16
-ldr X22, [sp], 16
-ldr X21, [sp], 16
-ldr X20, [sp], 16
-ldr X19, [sp], 16
-ldr X18, [sp], 16
-ldr X17, [sp], 16
-ldr X16, [sp], 16
-ret
+LDR X30, [sp], 16
+LDR X29, [sp], 16
+LDR X28, [sp], 16
+LDR X27, [sp], 16
+LDR X26, [sp], 16
+LDR X25, [sp], 16
+LDR X24, [sp], 16
+LDR X23, [sp], 16
+LDR X22, [sp], 16
+LDR X21, [sp], 16
+LDR X20, [sp], 16
+LDR X19, [sp], 16
+LDR X18, [sp], 16
+LDR X17, [sp], 16
+LDR X16, [sp], 16
+RET

--- a/lang/axcut2aarch64/tests/asm/nonLinear.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/nonLinear.aarch64.asm
@@ -25,21 +25,21 @@ asm_main7:
 _asm_main7:
 // setup
 // save registers
-str X16, [sp, -16]!
-str X17, [sp, -16]!
-str X18, [sp, -16]!
-str X19, [sp, -16]!
-str X20, [sp, -16]!
-str X21, [sp, -16]!
-str X22, [sp, -16]!
-str X23, [sp, -16]!
-str X24, [sp, -16]!
-str X25, [sp, -16]!
-str X26, [sp, -16]!
-str X27, [sp, -16]!
-str X28, [sp, -16]!
-str X29, [sp, -16]!
-str X30, [sp, -16]!
+STR X16, [sp, -16]!
+STR X17, [sp, -16]!
+STR X18, [sp, -16]!
+STR X19, [sp, -16]!
+STR X20, [sp, -16]!
+STR X21, [sp, -16]!
+STR X22, [sp, -16]!
+STR X23, [sp, -16]!
+STR X24, [sp, -16]!
+STR X25, [sp, -16]!
+STR X26, [sp, -16]!
+STR X27, [sp, -16]!
+STR X28, [sp, -16]!
+STR X29, [sp, -16]!
+STR X30, [sp, -16]!
 
 // move parameters into place
 
@@ -753,19 +753,19 @@ B cleanup
 // cleanup
 cleanup:
 // restore registers
-ldr X30, [sp], 16
-ldr X29, [sp], 16
-ldr X28, [sp], 16
-ldr X27, [sp], 16
-ldr X26, [sp], 16
-ldr X25, [sp], 16
-ldr X24, [sp], 16
-ldr X23, [sp], 16
-ldr X22, [sp], 16
-ldr X21, [sp], 16
-ldr X20, [sp], 16
-ldr X19, [sp], 16
-ldr X18, [sp], 16
-ldr X17, [sp], 16
-ldr X16, [sp], 16
-ret
+LDR X30, [sp], 16
+LDR X29, [sp], 16
+LDR X28, [sp], 16
+LDR X27, [sp], 16
+LDR X26, [sp], 16
+LDR X25, [sp], 16
+LDR X24, [sp], 16
+LDR X23, [sp], 16
+LDR X22, [sp], 16
+LDR X21, [sp], 16
+LDR X20, [sp], 16
+LDR X19, [sp], 16
+LDR X18, [sp], 16
+LDR X17, [sp], 16
+LDR X16, [sp], 16
+RET

--- a/lang/axcut2aarch64/tests/asm/quad.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/quad.aarch64.asm
@@ -25,21 +25,21 @@ asm_main7:
 _asm_main7:
 // setup
 // save registers
-str X16, [sp, -16]!
-str X17, [sp, -16]!
-str X18, [sp, -16]!
-str X19, [sp, -16]!
-str X20, [sp, -16]!
-str X21, [sp, -16]!
-str X22, [sp, -16]!
-str X23, [sp, -16]!
-str X24, [sp, -16]!
-str X25, [sp, -16]!
-str X26, [sp, -16]!
-str X27, [sp, -16]!
-str X28, [sp, -16]!
-str X29, [sp, -16]!
-str X30, [sp, -16]!
+STR X16, [sp, -16]!
+STR X17, [sp, -16]!
+STR X18, [sp, -16]!
+STR X19, [sp, -16]!
+STR X20, [sp, -16]!
+STR X21, [sp, -16]!
+STR X22, [sp, -16]!
+STR X23, [sp, -16]!
+STR X24, [sp, -16]!
+STR X25, [sp, -16]!
+STR X26, [sp, -16]!
+STR X27, [sp, -16]!
+STR X28, [sp, -16]!
+STR X29, [sp, -16]!
+STR X30, [sp, -16]!
 
 // move parameters into place
 
@@ -255,19 +255,19 @@ B cleanup
 // cleanup
 cleanup:
 // restore registers
-ldr X30, [sp], 16
-ldr X29, [sp], 16
-ldr X28, [sp], 16
-ldr X27, [sp], 16
-ldr X26, [sp], 16
-ldr X25, [sp], 16
-ldr X24, [sp], 16
-ldr X23, [sp], 16
-ldr X22, [sp], 16
-ldr X21, [sp], 16
-ldr X20, [sp], 16
-ldr X19, [sp], 16
-ldr X18, [sp], 16
-ldr X17, [sp], 16
-ldr X16, [sp], 16
-ret
+LDR X30, [sp], 16
+LDR X29, [sp], 16
+LDR X28, [sp], 16
+LDR X27, [sp], 16
+LDR X26, [sp], 16
+LDR X25, [sp], 16
+LDR X24, [sp], 16
+LDR X23, [sp], 16
+LDR X22, [sp], 16
+LDR X21, [sp], 16
+LDR X20, [sp], 16
+LDR X19, [sp], 16
+LDR X18, [sp], 16
+LDR X17, [sp], 16
+LDR X16, [sp], 16
+RET


### PR DESCRIPTION
The instructions for setup and cleanup in the aarch64 backend were in small letters but all other instructions were all-caps. This just makes all instructions all-caps for consistency. This should of course not change anything, but @BinderDavid could you please quickly confirm this by running some compiled program?