### PR TITLE
Rename focused syntax

### DIFF
--- a/lang/core/src/syntax/clause.rs
+++ b/lang/core/src/syntax/clause.rs
@@ -218,11 +218,11 @@ impl Uniquify for Clause {
 }
 
 impl Focusing for Clause {
-    type Target = crate::syntax_var::Clause;
+    type Target = crate::syntax_var::FsClause;
     ///N(K_i(x_{i,j}) => s_i ) = K_i(x_{i,j}) => N(s_i)
-    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::Clause {
+    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::FsClause {
         state.add_context(&self.context);
-        crate::syntax_var::Clause {
+        crate::syntax_var::FsClause {
             xtor: self.xtor,
             context: self.context.focus(state),
             case: self.rhs.focus(state),
@@ -284,30 +284,30 @@ mod transform_tests {
             ),
         }
     }
-    fn example_clause1_var() -> crate::syntax_var::Clause {
-        crate::syntax_var::Clause {
+    fn example_clause1_var() -> crate::syntax_var::FsClause {
+        crate::syntax_var::FsClause {
             xtor: "Tup".to_owned(),
             context: vec![
-                crate::syntax_var::ContextBinding {
+                crate::syntax_var::FsContextBinding {
                     chi: Chirality::Prd,
                     var: "x".to_owned(),
                     ty: crate::syntax::Ty::Int(),
                 },
-                crate::syntax_var::ContextBinding {
+                crate::syntax_var::FsContextBinding {
                     chi: Chirality::Prd,
                     var: "y".to_owned(),
                     ty: crate::syntax::Ty::Int(),
                 },
-                crate::syntax_var::ContextBinding {
+                crate::syntax_var::FsContextBinding {
                     chi: Chirality::Cns,
                     var: "a".to_owned(),
                     ty: crate::syntax::Ty::Int(),
                 },
             ],
             case: Rc::new(
-                crate::syntax_var::statement::Cut {
+                crate::syntax_var::statement::FsCut {
                     producer: Rc::new(
-                        crate::syntax_var::term::XVar {
+                        crate::syntax_var::term::FsXVar {
                             chi: Chirality::Prd,
                             var: "x".to_owned(),
                         }
@@ -315,7 +315,7 @@ mod transform_tests {
                     ),
                     ty: crate::syntax::Ty::Int(),
                     consumer: Rc::new(
-                        crate::syntax_var::term::XVar {
+                        crate::syntax_var::term::FsXVar {
                             chi: Chirality::Cns,
                             var: "a".to_owned(),
                         }
@@ -364,25 +364,25 @@ mod transform_tests {
             ),
         }
     }
-    fn example_clause2_var() -> crate::syntax_var::Clause {
-        crate::syntax_var::Clause {
+    fn example_clause2_var() -> crate::syntax_var::FsClause {
+        crate::syntax_var::FsClause {
             xtor: "Ap".to_owned(),
             context: vec![
-                crate::syntax_var::ContextBinding {
+                crate::syntax_var::FsContextBinding {
                     chi: Chirality::Prd,
                     var: "x".to_owned(),
                     ty: crate::syntax::Ty::Int(),
                 },
-                crate::syntax_var::ContextBinding {
+                crate::syntax_var::FsContextBinding {
                     chi: Chirality::Cns,
                     var: "a".to_owned(),
                     ty: crate::syntax::Ty::Int(),
                 },
             ],
             case: Rc::new(
-                crate::syntax_var::statement::Cut {
+                crate::syntax_var::statement::FsCut {
                     producer: Rc::new(
-                        crate::syntax_var::term::XVar {
+                        crate::syntax_var::term::FsXVar {
                             chi: Chirality::Prd,
                             var: "x".to_owned(),
                         }
@@ -390,7 +390,7 @@ mod transform_tests {
                     ),
                     ty: crate::syntax::Ty::Int(),
                     consumer: Rc::new(
-                        crate::syntax_var::term::XVar {
+                        crate::syntax_var::term::FsXVar {
                             chi: Chirality::Cns,
                             var: "a".to_owned(),
                         }

--- a/lang/core/src/syntax/context.rs
+++ b/lang/core/src/syntax/context.rs
@@ -89,8 +89,8 @@ mod context_tests {
 }
 
 impl Focusing for ContextBinding {
-    type Target = crate::syntax_var::ContextBinding;
-    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::ContextBinding {
+    type Target = crate::syntax_var::FsContextBinding;
+    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::FsContextBinding {
         state.add_context(&vec![self.clone()]);
         match self {
             ContextBinding::VarBinding { var, ty } => {
@@ -99,7 +99,7 @@ impl Focusing for ContextBinding {
                 } else {
                     crate::syntax_var::Chirality::Prd
                 };
-                crate::syntax_var::ContextBinding { var, chi, ty }
+                crate::syntax_var::FsContextBinding { var, chi, ty }
             }
             ContextBinding::CovarBinding { covar, ty } => {
                 let chi = if ty.is_codata(state.codata_types) {
@@ -107,7 +107,7 @@ impl Focusing for ContextBinding {
                 } else {
                     crate::syntax_var::Chirality::Cns
                 };
-                crate::syntax_var::ContextBinding {
+                crate::syntax_var::FsContextBinding {
                     var: covar,
                     chi,
                     ty,

--- a/lang/core/src/syntax/declaration.rs
+++ b/lang/core/src/syntax/declaration.rs
@@ -150,9 +150,9 @@ mod decl_tests {
 }
 
 impl<T> Focusing for XtorSig<T> {
-    type Target = crate::syntax_var::XtorSig;
-    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::XtorSig {
-        crate::syntax_var::XtorSig {
+    type Target = crate::syntax_var::FsXtorSig;
+    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::FsXtorSig {
+        crate::syntax_var::FsXtorSig {
             name: self.name,
             args: self.args.focus(state),
         }
@@ -160,9 +160,9 @@ impl<T> Focusing for XtorSig<T> {
 }
 
 impl<T> Focusing for TypeDeclaration<T> {
-    type Target = crate::syntax_var::TypeDeclaration;
-    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::TypeDeclaration {
-        crate::syntax_var::TypeDeclaration {
+    type Target = crate::syntax_var::FsTypeDeclaration;
+    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::FsTypeDeclaration {
+        crate::syntax_var::FsTypeDeclaration {
             name: self.name,
             xtors: self.xtors.focus(state),
         }

--- a/lang/core/src/syntax/def.rs
+++ b/lang/core/src/syntax/def.rs
@@ -42,9 +42,9 @@ impl Print for Def {
 }
 
 impl Focusing for Def {
-    type Target = crate::syntax_var::Def;
-    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::Def {
-        crate::syntax_var::Def {
+    type Target = crate::syntax_var::FsDef;
+    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::FsDef {
+        crate::syntax_var::FsDef {
             name: self.name,
             context: self.context.focus(state),
             body: self.body.focus(state),

--- a/lang/core/src/syntax/program.rs
+++ b/lang/core/src/syntax/program.rs
@@ -130,14 +130,14 @@ mod program_tests {
 }
 
 #[must_use]
-pub fn transform_prog(prog: Prog) -> crate::syntax_var::Prog {
+pub fn transform_prog(prog: Prog) -> crate::syntax_var::FsProg {
     let codata_types_clone = prog.codata_types.clone();
     let mut state = FocusingState {
         codata_types: codata_types_clone.as_slice(),
         ..FocusingState::default()
     };
 
-    crate::syntax_var::Prog {
+    crate::syntax_var::FsProg {
         defs: prog
             .defs
             .into_iter()
@@ -185,11 +185,11 @@ mod transform_prog_tests {
             body: Statement::Done(Ty::Int()),
         }
     }
-    fn example_def1_var() -> crate::syntax_var::Def {
-        crate::syntax_var::Def {
+    fn example_def1_var() -> crate::syntax_var::FsDef {
+        crate::syntax_var::FsDef {
             name: "done".to_owned(),
             context: vec![],
-            body: crate::syntax_var::Statement::Done(),
+            body: crate::syntax_var::FsStatement::Done(),
             used_vars: HashSet::new(),
         }
     }
@@ -229,24 +229,24 @@ mod transform_prog_tests {
             .into(),
         }
     }
-    fn example_def2_var() -> crate::syntax_var::Def {
-        crate::syntax_var::Def {
+    fn example_def2_var() -> crate::syntax_var::FsDef {
+        crate::syntax_var::FsDef {
             name: "cut".to_owned(),
             context: vec![
-                crate::syntax_var::ContextBinding {
+                crate::syntax_var::FsContextBinding {
                     chi: Chirality::Prd,
                     var: "x".to_owned(),
                     ty: crate::syntax::Ty::Int(),
                 },
-                crate::syntax_var::ContextBinding {
+                crate::syntax_var::FsContextBinding {
                     chi: Chirality::Cns,
                     var: "a".to_owned(),
                     ty: crate::syntax::Ty::Int(),
                 },
             ],
-            body: crate::syntax_var::statement::Cut {
+            body: crate::syntax_var::statement::FsCut {
                 producer: Rc::new(
-                    crate::syntax_var::term::XVar {
+                    crate::syntax_var::term::FsXVar {
                         chi: Chirality::Prd,
                         var: "x".to_owned(),
                     }
@@ -254,7 +254,7 @@ mod transform_prog_tests {
                 ),
                 ty: crate::syntax::Ty::Int(),
                 consumer: Rc::new(
-                    crate::syntax_var::term::XVar {
+                    crate::syntax_var::term::FsXVar {
                         chi: Chirality::Cns,
                         var: "a".to_owned(),
                     }

--- a/lang/core/src/syntax/statement/fun.rs
+++ b/lang/core/src/syntax/statement/fun.rs
@@ -90,13 +90,13 @@ impl Uniquify for Fun {
 }
 
 impl Focusing for Fun {
-    type Target = crate::syntax_var::Statement;
+    type Target = crate::syntax_var::FsStatement;
     ///N(f(t_i)) = bind(t_i)[λas.f(as)]
-    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         bind_many(
             self.args.into(),
             Box::new(|args, _: &mut FocusingState| {
-                crate::syntax_var::statement::Call {
+                crate::syntax_var::statement::FsCall {
                     name: self.name,
                     args: args.into_iter().collect(),
                 }
@@ -133,7 +133,7 @@ mod transform_tests {
     #[test]
     fn transform_fun1() {
         let result = example_fun1().focus(&mut Default::default());
-        let expected = crate::syntax_var::statement::Call {
+        let expected = crate::syntax_var::statement::FsCall {
             name: "main".to_owned(),
             args: vec![],
         }
@@ -144,7 +144,7 @@ mod transform_tests {
     #[test]
     fn transform_fun2() {
         let result = example_fun2().focus(&mut Default::default());
-        let expected = crate::syntax_var::statement::Call {
+        let expected = crate::syntax_var::statement::FsCall {
             name: "fun".to_owned(),
             args: vec!["x".to_string(), "a".to_string()],
         }

--- a/lang/core/src/syntax/statement/ife.rs
+++ b/lang/core/src/syntax/statement/ife.rs
@@ -130,13 +130,13 @@ impl Uniquify for IfE {
 }
 
 impl Focusing for IfE {
-    type Target = crate::syntax_var::Statement;
+    type Target = crate::syntax_var::FsStatement;
     ///N(ifz(p_1, p_2, s_1, s_2)) = bind(p_1)[λa1.bind(p_1)[λa2.ifz(a_1, a_2, N(s_1), N(s_2))]]
-    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         let cont = Box::new(|var_fst, state: &mut FocusingState| {
             Rc::unwrap_or_clone(self.snd).bind(
                 Box::new(|var_snd: Var, state: &mut FocusingState| {
-                    crate::syntax_var::statement::IfE {
+                    crate::syntax_var::statement::FsIfE {
                         fst: var_fst,
                         snd: var_snd,
                         thenc: self.thenc.focus(state),
@@ -190,16 +190,16 @@ mod transform_tests {
             ),
         }
     }
-    fn example_ife2_var() -> crate::syntax_var::statement::IfE {
-        crate::syntax_var::statement::IfE {
+    fn example_ife2_var() -> crate::syntax_var::statement::FsIfE {
+        crate::syntax_var::statement::FsIfE {
             fst: "x".to_string(),
             snd: "x".to_string(),
-            thenc: Rc::new(crate::syntax_var::Statement::Done()),
+            thenc: Rc::new(crate::syntax_var::FsStatement::Done()),
             elsec: Rc::new(
-                crate::syntax_var::statement::Cut::new(
+                crate::syntax_var::statement::FsCut::new(
                     crate::syntax::Ty::Int(),
-                    crate::syntax_var::term::XVar::var("x"),
-                    crate::syntax_var::term::XVar::covar("a"),
+                    crate::syntax_var::term::FsXVar::var("x"),
+                    crate::syntax_var::term::FsXVar::covar("a"),
                 )
                 .into(),
             ),
@@ -209,34 +209,34 @@ mod transform_tests {
     #[test]
     fn transform_ife1() {
         let result = example_ife1().focus(&mut Default::default());
-        let expected = crate::syntax_var::statement::Cut {
+        let expected = crate::syntax_var::statement::FsCut {
             ty: crate::syntax::Ty::Int(),
-            producer: Rc::new(crate::syntax_var::term::Literal { lit: 2 }.into()),
+            producer: Rc::new(crate::syntax_var::term::FsLiteral { lit: 2 }.into()),
             consumer: Rc::new(
-                crate::syntax_var::term::Mu {
+                crate::syntax_var::term::FsMu {
                     chi: Chirality::Cns,
                     variable: "x0".to_owned(),
                     statement: Rc::new(
-                        crate::syntax_var::statement::Cut {
+                        crate::syntax_var::statement::FsCut {
                             ty: crate::syntax::Ty::Int(),
-                            producer: Rc::new(crate::syntax_var::term::Literal { lit: 1 }.into()),
+                            producer: Rc::new(crate::syntax_var::term::FsLiteral { lit: 1 }.into()),
                             consumer: Rc::new(
-                                crate::syntax_var::term::Mu {
+                                crate::syntax_var::term::FsMu {
                                     chi: Chirality::Cns,
                                     variable: "x1".to_owned(),
                                     statement: Rc::new(
-                                        crate::syntax_var::statement::IfE {
+                                        crate::syntax_var::statement::FsIfE {
                                             fst: "x0".to_string(),
                                             snd: "x1".to_string(),
                                             thenc: Rc::new(
-                                                crate::syntax_var::statement::Cut::new(
+                                                crate::syntax_var::statement::FsCut::new(
                                                     crate::syntax::Ty::Int(),
-                                                    crate::syntax_var::term::Literal::new(1),
-                                                    crate::syntax_var::term::XVar::covar("a"),
+                                                    crate::syntax_var::term::FsLiteral::new(1),
+                                                    crate::syntax_var::term::FsXVar::covar("a"),
                                                 )
                                                 .into(),
                                             ),
-                                            elsec: Rc::new(crate::syntax_var::Statement::Done()),
+                                            elsec: Rc::new(crate::syntax_var::FsStatement::Done()),
                                         }
                                         .into(),
                                     ),

--- a/lang/core/src/syntax/statement/ifl.rs
+++ b/lang/core/src/syntax/statement/ifl.rs
@@ -130,13 +130,13 @@ impl Uniquify for IfL {
 }
 
 impl Focusing for IfL {
-    type Target = crate::syntax_var::Statement;
+    type Target = crate::syntax_var::FsStatement;
     ///N(ifz(p_1, p_2, s_1, s_2)) = bind(p_1)[λa1.bind(p_1)[λa2.ifz(a_1, a_2, N(s_1), N(s_2))]]
-    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         let cont = Box::new(|var_fst, state: &mut FocusingState| {
             Rc::unwrap_or_clone(self.snd).bind(
                 Box::new(|var_snd: Var, state: &mut FocusingState| {
-                    crate::syntax_var::statement::IfL {
+                    crate::syntax_var::statement::FsIfL {
                         fst: var_fst,
                         snd: var_snd,
                         thenc: self.thenc.focus(state),
@@ -190,16 +190,16 @@ mod transform_tests {
             ),
         }
     }
-    fn example_ifl2_var() -> crate::syntax_var::statement::IfL {
-        crate::syntax_var::statement::IfL {
+    fn example_ifl2_var() -> crate::syntax_var::statement::FsIfL {
+        crate::syntax_var::statement::FsIfL {
             fst: "x".to_string(),
             snd: "x".to_string(),
-            thenc: Rc::new(crate::syntax_var::Statement::Done()),
+            thenc: Rc::new(crate::syntax_var::FsStatement::Done()),
             elsec: Rc::new(
-                crate::syntax_var::statement::Cut::new(
+                crate::syntax_var::statement::FsCut::new(
                     crate::syntax::Ty::Int(),
-                    crate::syntax_var::term::XVar::var("x"),
-                    crate::syntax_var::term::XVar::covar("a"),
+                    crate::syntax_var::term::FsXVar::var("x"),
+                    crate::syntax_var::term::FsXVar::covar("a"),
                 )
                 .into(),
             ),
@@ -209,34 +209,34 @@ mod transform_tests {
     #[test]
     fn transform_ifl1() {
         let result = example_ifl1().focus(&mut Default::default());
-        let expected = crate::syntax_var::statement::Cut {
+        let expected = crate::syntax_var::statement::FsCut {
             ty: crate::syntax::Ty::Int(),
-            producer: Rc::new(crate::syntax_var::term::Literal { lit: 2 }.into()),
+            producer: Rc::new(crate::syntax_var::term::FsLiteral { lit: 2 }.into()),
             consumer: Rc::new(
-                crate::syntax_var::term::Mu {
+                crate::syntax_var::term::FsMu {
                     chi: Chirality::Cns,
                     variable: "x0".to_owned(),
                     statement: Rc::new(
-                        crate::syntax_var::statement::Cut {
+                        crate::syntax_var::statement::FsCut {
                             ty: crate::syntax::Ty::Int(),
-                            producer: Rc::new(crate::syntax_var::term::Literal { lit: 1 }.into()),
+                            producer: Rc::new(crate::syntax_var::term::FsLiteral { lit: 1 }.into()),
                             consumer: Rc::new(
-                                crate::syntax_var::term::Mu {
+                                crate::syntax_var::term::FsMu {
                                     chi: Chirality::Cns,
                                     variable: "x1".to_owned(),
                                     statement: Rc::new(
-                                        crate::syntax_var::statement::IfL {
+                                        crate::syntax_var::statement::FsIfL {
                                             fst: "x0".to_string(),
                                             snd: "x1".to_string(),
                                             thenc: Rc::new(
-                                                crate::syntax_var::statement::Cut::new(
+                                                crate::syntax_var::statement::FsCut::new(
                                                     crate::syntax::Ty::Int(),
-                                                    crate::syntax_var::term::Literal::new(1),
-                                                    crate::syntax_var::term::XVar::covar("a"),
+                                                    crate::syntax_var::term::FsLiteral::new(1),
+                                                    crate::syntax_var::term::FsXVar::covar("a"),
                                                 )
                                                 .into(),
                                             ),
-                                            elsec: Rc::new(crate::syntax_var::Statement::Done()),
+                                            elsec: Rc::new(crate::syntax_var::FsStatement::Done()),
                                         }
                                         .into(),
                                     ),

--- a/lang/core/src/syntax/statement/ifz.rs
+++ b/lang/core/src/syntax/statement/ifz.rs
@@ -116,11 +116,11 @@ impl Uniquify for IfZ {
 }
 
 impl Focusing for IfZ {
-    type Target = crate::syntax_var::Statement;
+    type Target = crate::syntax_var::FsStatement;
     ///N(ifz(p, s_1, s_2)) = bind(p)[λa.ifz(a, N(s_1), N(s_2))]
-    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         let cont = Box::new(|var, state: &mut FocusingState| {
-            crate::syntax_var::statement::IfZ {
+            crate::syntax_var::statement::FsIfZ {
                 ifc: var,
                 thenc: self.thenc.focus(state),
                 elsec: self.elsec.focus(state),
@@ -168,15 +168,15 @@ mod transform_tests {
             ),
         }
     }
-    fn example_ifz2_var() -> crate::syntax_var::statement::IfZ {
-        crate::syntax_var::statement::IfZ {
+    fn example_ifz2_var() -> crate::syntax_var::statement::FsIfZ {
+        crate::syntax_var::statement::FsIfZ {
             ifc: "x".to_string(),
-            thenc: Rc::new(crate::syntax_var::Statement::Done()),
+            thenc: Rc::new(crate::syntax_var::FsStatement::Done()),
             elsec: Rc::new(
-                crate::syntax_var::statement::Cut::new(
+                crate::syntax_var::statement::FsCut::new(
                     crate::syntax::Ty::Int(),
-                    crate::syntax_var::term::XVar::var("x"),
-                    crate::syntax_var::term::XVar::covar("a"),
+                    crate::syntax_var::term::FsXVar::var("x"),
+                    crate::syntax_var::term::FsXVar::covar("a"),
                 )
                 .into(),
             ),
@@ -186,25 +186,25 @@ mod transform_tests {
     #[test]
     fn transform_ifz1() {
         let result = example_ifz1().focus(&mut Default::default());
-        let expected = crate::syntax_var::statement::Cut {
+        let expected = crate::syntax_var::statement::FsCut {
             ty: crate::syntax::Ty::Int(),
-            producer: Rc::new(crate::syntax_var::term::Literal { lit: 1 }.into()),
+            producer: Rc::new(crate::syntax_var::term::FsLiteral { lit: 1 }.into()),
             consumer: Rc::new(
-                crate::syntax_var::term::Mu {
+                crate::syntax_var::term::FsMu {
                     chi: Chirality::Cns,
                     variable: "x0".to_owned(),
                     statement: Rc::new(
-                        crate::syntax_var::statement::IfZ {
+                        crate::syntax_var::statement::FsIfZ {
                             ifc: "x0".to_string(),
                             thenc: Rc::new(
-                                crate::syntax_var::statement::Cut::new(
+                                crate::syntax_var::statement::FsCut::new(
                                     crate::syntax::Ty::Int(),
-                                    crate::syntax_var::term::Literal::new(1),
-                                    crate::syntax_var::term::XVar::covar("a"),
+                                    crate::syntax_var::term::FsLiteral::new(1),
+                                    crate::syntax_var::term::FsXVar::covar("a"),
                                 )
                                 .into(),
                             ),
-                            elsec: Rc::new(crate::syntax_var::Statement::Done()),
+                            elsec: Rc::new(crate::syntax_var::FsStatement::Done()),
                         }
                         .into(),
                     ),

--- a/lang/core/src/syntax/statement/mod.rs
+++ b/lang/core/src/syntax/statement/mod.rs
@@ -587,8 +587,8 @@ impl Uniquify for Statement {
 }
 
 impl Focusing for Statement {
-    type Target = crate::syntax_var::Statement;
-    fn focus(self: Statement, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    type Target = crate::syntax_var::FsStatement;
+    fn focus(self: Statement, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         match self {
             Statement::Cut(cut) => cut.focus(state),
             Statement::Op(op) => op.focus(state),
@@ -596,7 +596,7 @@ impl Focusing for Statement {
             Statement::IfL(ifl) => ifl.focus(state),
             Statement::IfZ(ifz) => ifz.focus(state),
             Statement::Fun(call) => call.focus(state),
-            Statement::Done(_) => crate::syntax_var::Statement::Done(),
+            Statement::Done(_) => crate::syntax_var::FsStatement::Done(),
         }
     }
 }
@@ -719,7 +719,7 @@ mod statement_tests {
     #[test]
     fn transform_done() {
         let result = example_done().focus(&mut Default::default());
-        let expected = crate::syntax_var::Statement::Done();
+        let expected = crate::syntax_var::FsStatement::Done();
         assert_eq!(result, expected)
     }
 }

--- a/lang/core/src/syntax/statement/op.rs
+++ b/lang/core/src/syntax/statement/op.rs
@@ -113,13 +113,13 @@ impl Uniquify for Op {
 }
 
 impl Focusing for Op {
-    type Target = crate::syntax_var::Statement;
+    type Target = crate::syntax_var::FsStatement;
     ///N(⊙ (p_1, p_2; c)) = bind(p_1)[λa1.bind(p_2)[λa_2.⊙ (a_1, a_2; N(c))]]
-    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn focus(self, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         let cont = Box::new(|var_fst: Var, state: &mut FocusingState| {
             Rc::unwrap_or_clone(self.snd).bind(
                 Box::new(|var_snd: Var, state: &mut FocusingState| {
-                    crate::syntax_var::statement::Op {
+                    crate::syntax_var::statement::FsOp {
                         fst: var_fst,
                         op: self.op,
                         snd: var_snd,
@@ -164,40 +164,40 @@ mod transform_tests {
             continuation: Rc::new(XVar::covar("a", Ty::Int()).into()),
         }
     }
-    fn example_op2_var() -> crate::syntax_var::statement::Op {
-        crate::syntax_var::statement::Op {
+    fn example_op2_var() -> crate::syntax_var::statement::FsOp {
+        crate::syntax_var::statement::FsOp {
             fst: "x".to_owned(),
             op: crate::syntax::BinOp::Prod,
             snd: "y".to_owned(),
-            continuation: Rc::new(crate::syntax_var::term::XVar::covar("a").into()),
+            continuation: Rc::new(crate::syntax_var::term::FsXVar::covar("a").into()),
         }
     }
 
     #[test]
     fn transform_op1() {
         let result = example_op1().focus(&mut Default::default());
-        let expected = crate::syntax_var::statement::Cut {
-            producer: Rc::new(crate::syntax_var::term::Literal { lit: 1 }.into()),
+        let expected = crate::syntax_var::statement::FsCut {
+            producer: Rc::new(crate::syntax_var::term::FsLiteral { lit: 1 }.into()),
             ty: crate::syntax::Ty::Int(),
             consumer: Rc::new(
-                crate::syntax_var::term::Mu {
+                crate::syntax_var::term::FsMu {
                     chi: Chirality::Cns,
                     variable: "x0".to_owned(),
                     statement: Rc::new(
-                        crate::syntax_var::statement::Cut {
-                            producer: Rc::new(crate::syntax_var::term::Literal { lit: 2 }.into()),
+                        crate::syntax_var::statement::FsCut {
+                            producer: Rc::new(crate::syntax_var::term::FsLiteral { lit: 2 }.into()),
                             ty: crate::syntax::Ty::Int(),
                             consumer: Rc::new(
-                                crate::syntax_var::term::Mu {
+                                crate::syntax_var::term::FsMu {
                                     chi: Chirality::Cns,
                                     variable: "x1".to_owned(),
                                     statement: Rc::new(
-                                        crate::syntax_var::statement::Op {
+                                        crate::syntax_var::statement::FsOp {
                                             fst: "x0".to_string(),
                                             op: crate::syntax::BinOp::Sum,
                                             snd: "x1".to_string(),
                                             continuation: Rc::new(
-                                                crate::syntax_var::term::XVar::covar("a").into(),
+                                                crate::syntax_var::term::FsXVar::covar("a").into(),
                                             ),
                                         }
                                         .into(),

--- a/lang/core/src/syntax/substitution.rs
+++ b/lang/core/src/syntax/substitution.rs
@@ -114,7 +114,7 @@ impl Focusing for SubstitutionBinding {
 }
 
 impl Bind for SubstitutionBinding {
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         match self {
             SubstitutionBinding::ProducerBinding(prd) => prd.bind(k, state),
             SubstitutionBinding::ConsumerBinding(cns) => cns.bind(k, state),

--- a/lang/core/src/syntax/term/literal.rs
+++ b/lang/core/src/syntax/term/literal.rs
@@ -71,20 +71,20 @@ impl Subst for Literal {
 }
 
 impl Focusing for Literal {
-    type Target = crate::syntax_var::term::Literal;
+    type Target = crate::syntax_var::term::FsLiteral;
     fn focus(self, _: &mut FocusingState) -> Self::Target {
-        crate::syntax_var::term::Literal::new(self.lit)
+        crate::syntax_var::term::FsLiteral::new(self.lit)
     }
 }
 
 impl Bind for Literal {
     ///bind(⌜n⌝)[k] = ⟨⌜n⌝ | ~μx.k(x)⟩
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         let new_var = state.fresh_var();
-        crate::syntax_var::statement::Cut::new(
+        crate::syntax_var::statement::FsCut::new(
             crate::syntax::Ty::Int(),
-            crate::syntax_var::term::Literal::new(self.lit),
-            crate::syntax_var::term::Mu::tilde_mu(&new_var, k(new_var.clone(), state)),
+            crate::syntax_var::term::FsLiteral::new(self.lit),
+            crate::syntax_var::term::FsMu::tilde_mu(&new_var, k(new_var.clone(), state)),
         )
         .into()
     }
@@ -139,24 +139,24 @@ mod lit_tests {
     #[test]
     fn focus_lit() {
         let result = Literal::new(1).focus(&mut Default::default());
-        let expected = crate::syntax_var::term::Literal::new(1);
+        let expected = crate::syntax_var::term::FsLiteral::new(1);
         assert_eq!(result, expected)
     }
 
     #[test]
     fn bind_lit1() {
         let result = Literal::new(1).bind(
-            Box::new(|_, _| crate::syntax_var::Statement::Done()),
+            Box::new(|_, _| crate::syntax_var::FsStatement::Done()),
             &mut Default::default(),
         );
-        let expected = crate::syntax_var::statement::Cut {
-            producer: Rc::new(crate::syntax_var::term::Literal::new(1).into()),
+        let expected = crate::syntax_var::statement::FsCut {
+            producer: Rc::new(crate::syntax_var::term::FsLiteral::new(1).into()),
             ty: crate::syntax::Ty::Int(),
             consumer: Rc::new(
-                crate::syntax_var::term::Mu {
+                crate::syntax_var::term::FsMu {
                     chi: Chirality::Cns,
                     variable: "x0".to_owned(),
-                    statement: Rc::new(crate::syntax_var::Statement::Done()),
+                    statement: Rc::new(crate::syntax_var::FsStatement::Done()),
                 }
                 .into(),
             ),
@@ -168,17 +168,17 @@ mod lit_tests {
     #[test]
     fn bind_lit2() {
         let result = Literal::new(2).bind(
-            Box::new(|_, _| crate::syntax_var::Statement::Done()),
+            Box::new(|_, _| crate::syntax_var::FsStatement::Done()),
             &mut Default::default(),
         );
-        let expected = crate::syntax_var::statement::Cut {
-            producer: Rc::new(crate::syntax_var::term::Literal::new(2).into()),
+        let expected = crate::syntax_var::statement::FsCut {
+            producer: Rc::new(crate::syntax_var::term::FsLiteral::new(2).into()),
             ty: crate::syntax::Ty::Int(),
             consumer: Rc::new(
-                crate::syntax_var::term::Mu {
+                crate::syntax_var::term::FsMu {
                     chi: Chirality::Cns,
                     variable: "x0".to_owned(),
-                    statement: Rc::new(crate::syntax_var::Statement::Done()),
+                    statement: Rc::new(crate::syntax_var::FsStatement::Done()),
                 }
                 .into(),
             ),

--- a/lang/core/src/syntax/term/mod.rs
+++ b/lang/core/src/syntax/term/mod.rs
@@ -167,7 +167,7 @@ impl<T: PrdCns> Uniquify for Term<T> {
 }
 
 impl Focusing for Term<Prd> {
-    type Target = crate::syntax_var::Term;
+    type Target = crate::syntax_var::FsTerm;
 
     fn focus(self, st: &mut FocusingState) -> Self::Target {
         match self {
@@ -180,7 +180,7 @@ impl Focusing for Term<Prd> {
     }
 }
 impl Focusing for Term<Cns> {
-    type Target = crate::syntax_var::Term;
+    type Target = crate::syntax_var::FsTerm;
 
     fn focus(self, st: &mut FocusingState) -> Self::Target {
         match self {
@@ -194,7 +194,7 @@ impl Focusing for Term<Cns> {
 }
 
 impl Bind for Term<Prd> {
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         match self {
             Term::XVar(var) => var.bind(k, state),
             Term::Literal(lit) => lit.bind(k, state),
@@ -205,7 +205,7 @@ impl Bind for Term<Prd> {
     }
 }
 impl Bind for Term<Cns> {
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         match self {
             Term::XVar(covar) => covar.bind(k, state),
             Term::Literal(lit) => lit.bind(k, state),

--- a/lang/core/src/syntax/term/xcase.rs
+++ b/lang/core/src/syntax/term/xcase.rs
@@ -118,11 +118,11 @@ impl<T: PrdCns> Uniquify for XCase<T> {
 }
 
 impl<T: PrdCns> Focusing for XCase<T> {
-    type Target = crate::syntax_var::term::XCase;
+    type Target = crate::syntax_var::term::FsXCase;
 
     ///N(case {cases}) = case { N(cases) } AND N(cocase {cases}) = case { N(cases) }
     fn focus(self, state: &mut FocusingState) -> Self::Target {
-        crate::syntax_var::term::XCase {
+        crate::syntax_var::term::FsXCase {
             clauses: self.clauses.focus(state),
         }
     }
@@ -131,11 +131,11 @@ impl<T: PrdCns> Focusing for XCase<T> {
 impl<T: PrdCns> Bind for XCase<T> {
     ///bind(case {cases)[k] = ⟨μa.k(a) | case N{cases}⟩
     ///AND bind(cocase {cases)[k] = ⟨μa.k(a) | case N{cases}⟩
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         let new_covar = state.fresh_covar();
-        let prod = crate::syntax_var::term::Mu::mu(&new_covar, k(new_covar.clone(), state));
+        let prod = crate::syntax_var::term::FsMu::mu(&new_covar, k(new_covar.clone(), state));
         let ty = self.ty.clone();
-        crate::syntax_var::statement::Cut::new(ty, prod, self.focus(state)).into()
+        crate::syntax_var::statement::FsCut::new(ty, prod, self.focus(state)).into()
     }
 }
 

--- a/lang/core/src/syntax/term/xtor.rs
+++ b/lang/core/src/syntax/term/xtor.rs
@@ -124,7 +124,7 @@ impl<T: PrdCns> Uniquify for Xtor<T> {
 }
 
 impl<T: PrdCns> Focusing for Xtor<T> {
-    type Target = crate::syntax_var::Term;
+    type Target = crate::syntax_var::FsTerm;
     fn focus(self, _: &mut FocusingState) -> Self::Target {
         panic!("Constructors and destructors should always be focused in cuts directly");
     }
@@ -133,18 +133,18 @@ impl<T: PrdCns> Focusing for Xtor<T> {
 impl<T: PrdCns> Bind for Xtor<T> {
     ///bind(C(t_i))[k] = bind(t_i)[λas.⟨C(as) | ~μx.k(x)⟩]
     ///AND bind(D(t_i))[k] = bind(t_i)[λas.⟨D(as) | ~μx.k(x)⟩]
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         let new_var = state.fresh_var();
         bind_many(
             self.args.into(),
             Box::new(|vars, state: &mut FocusingState| {
-                crate::syntax_var::statement::Cut::new(
+                crate::syntax_var::statement::FsCut::new(
                     self.ty,
-                    crate::syntax_var::term::Term::Xtor(crate::syntax_var::term::Xtor {
+                    crate::syntax_var::term::FsTerm::Xtor(crate::syntax_var::term::FsXtor {
                         id: self.id,
                         args: vars.into_iter().collect(),
                     }),
-                    crate::syntax_var::term::Mu::tilde_mu(&new_var.clone(), k(new_var, state)),
+                    crate::syntax_var::term::FsMu::tilde_mu(&new_var.clone(), k(new_var, state)),
                 )
                 .into()
             }),

--- a/lang/core/src/syntax/term/xvar.rs
+++ b/lang/core/src/syntax/term/xvar.rs
@@ -130,7 +130,7 @@ impl Subst for XVar<Cns> {
 }
 
 impl<T: PrdCns> Focusing for XVar<T> {
-    type Target = crate::syntax_var::term::XVar;
+    type Target = crate::syntax_var::term::FsXVar;
     fn focus(self, state: &mut FocusingState) -> Self::Target {
         let chi = if (self.prdcns.is_prd() && !self.ty.is_codata(state.codata_types))
             || (self.prdcns.is_cns() && self.ty.is_codata(state.codata_types))
@@ -139,12 +139,12 @@ impl<T: PrdCns> Focusing for XVar<T> {
         } else {
             crate::syntax_var::Chirality::Cns
         };
-        crate::syntax_var::term::XVar { chi, var: self.var }
+        crate::syntax_var::term::FsXVar { chi, var: self.var }
     }
 }
 
 impl<T: PrdCns> Bind for XVar<T> {
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::Statement {
+    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::FsStatement {
         k(self.var, state)
     }
 }

--- a/lang/core/src/syntax_var/clause.rs
+++ b/lang/core/src/syntax_var/clause.rs
@@ -2,19 +2,19 @@ use printer::tokens::COMMA;
 use printer::util::BracesExt;
 use printer::{tokens::FAT_ARROW, DocAllocator, Print};
 
-use super::{Name, Statement, TypingContext, Var};
+use super::{FsStatement, FsTypingContext, Name, Var};
 use crate::traits::substitution::SubstVar;
 
 use std::rc::Rc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Clause {
+pub struct FsClause {
     pub xtor: Name,
-    pub context: TypingContext,
-    pub case: Rc<Statement>,
+    pub context: FsTypingContext,
+    pub case: Rc<FsStatement>,
 }
 
-impl Print for Clause {
+impl Print for FsClause {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -39,7 +39,7 @@ impl Print for Clause {
 }
 
 pub fn print_clauses<'a>(
-    cases: &'a [Clause],
+    cases: &'a [FsClause],
     cfg: &printer::PrintCfg,
     alloc: &'a printer::Alloc<'a>,
 ) -> printer::Builder<'a> {
@@ -65,11 +65,11 @@ pub fn print_clauses<'a>(
     }
 }
 
-impl SubstVar for Clause {
-    type Target = Clause;
+impl SubstVar for FsClause {
+    type Target = FsClause;
 
-    fn subst_sim(self, subst: &[(Var, Var)]) -> Clause {
-        Clause {
+    fn subst_sim(self, subst: &[(Var, Var)]) -> FsClause {
+        FsClause {
             case: self.case.subst_sim(subst),
             ..self
         }

--- a/lang/core/src/syntax_var/context.rs
+++ b/lang/core/src/syntax_var/context.rs
@@ -5,15 +5,15 @@ use crate::{syntax::Ty, traits::substitution::SubstVar};
 use super::{Chirality, Var};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct ContextBinding {
+pub struct FsContextBinding {
     pub var: Var,
     pub chi: Chirality,
     pub ty: Ty,
 }
 
-pub type TypingContext = Vec<ContextBinding>;
+pub type FsTypingContext = Vec<FsContextBinding>;
 
-impl Print for ContextBinding {
+impl Print for FsContextBinding {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -29,11 +29,11 @@ impl Print for ContextBinding {
     }
 }
 
-impl SubstVar for ContextBinding {
-    type Target = ContextBinding;
+impl SubstVar for FsContextBinding {
+    type Target = FsContextBinding;
 
-    fn subst_sim(self, subst: &[(Var, Var)]) -> ContextBinding {
-        ContextBinding {
+    fn subst_sim(self, subst: &[(Var, Var)]) -> FsContextBinding {
+        FsContextBinding {
             var: self.var.subst_sim(subst),
             ..self
         }
@@ -41,7 +41,7 @@ impl SubstVar for ContextBinding {
 }
 
 #[must_use]
-pub fn context_vars(context: &TypingContext) -> Vec<Var> {
+pub fn context_vars(context: &FsTypingContext) -> Vec<Var> {
     let mut vars = Vec::with_capacity(context.len());
     for binding in context {
         vars.push(binding.var.clone());

--- a/lang/core/src/syntax_var/declaration.rs
+++ b/lang/core/src/syntax_var/declaration.rs
@@ -2,27 +2,27 @@ use printer::{theme::ThemeExt, tokens::TYPE, util::BracesExt, DocAllocator, Prin
 
 use crate::syntax::Ty;
 
-use super::{Chirality, ContextBinding, Name, TypingContext};
+use super::{Chirality, FsContextBinding, FsTypingContext, Name};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct XtorSig {
+pub struct FsXtorSig {
     pub name: Name,
-    pub args: TypingContext,
+    pub args: FsTypingContext,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct TypeDeclaration {
+pub struct FsTypeDeclaration {
     pub name: Name,
-    pub xtors: Vec<XtorSig>,
+    pub xtors: Vec<FsXtorSig>,
 }
 
 #[must_use]
-pub fn cont_int() -> TypeDeclaration {
-    TypeDeclaration {
+pub fn cont_int() -> FsTypeDeclaration {
+    FsTypeDeclaration {
         name: "_Cont".to_string(),
-        xtors: vec![XtorSig {
+        xtors: vec![FsXtorSig {
             name: "_Ret".to_string(),
-            args: vec![ContextBinding {
+            args: vec![FsContextBinding {
                 var: "x".to_string(),
                 chi: Chirality::Prd,
                 ty: Ty::Int(),
@@ -34,8 +34,8 @@ pub fn cont_int() -> TypeDeclaration {
 #[must_use]
 pub fn lookup_type_declaration<'a>(
     type_name: &String,
-    types: &'a [TypeDeclaration],
-) -> &'a TypeDeclaration {
+    types: &'a [FsTypeDeclaration],
+) -> &'a FsTypeDeclaration {
     let type_declaration = types
         .iter()
         .find(|declaration| declaration.name == *type_name)
@@ -43,7 +43,7 @@ pub fn lookup_type_declaration<'a>(
     type_declaration
 }
 
-impl Print for XtorSig {
+impl Print for FsXtorSig {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -59,7 +59,7 @@ impl Print for XtorSig {
     }
 }
 
-impl Print for TypeDeclaration {
+impl Print for FsTypeDeclaration {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,

--- a/lang/core/src/syntax_var/def.rs
+++ b/lang/core/src/syntax_var/def.rs
@@ -4,19 +4,19 @@ use printer::{
     DocAllocator, Print,
 };
 
-use super::{Name, Statement, TypingContext, Var};
+use super::{FsStatement, FsTypingContext, Name, Var};
 
 use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Def {
+pub struct FsDef {
     pub name: Name,
-    pub context: TypingContext,
-    pub body: Statement,
+    pub context: FsTypingContext,
+    pub body: FsStatement,
     pub used_vars: HashSet<Var>,
 }
 
-impl Print for Def {
+impl Print for FsDef {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,

--- a/lang/core/src/syntax_var/mod.rs
+++ b/lang/core/src/syntax_var/mod.rs
@@ -9,11 +9,11 @@ pub mod statement;
 pub mod term;
 
 pub use chirality::Chirality;
-pub use clause::Clause;
-pub use context::{ContextBinding, TypingContext};
-pub use declaration::{cont_int, TypeDeclaration, XtorSig};
-pub use def::Def;
+pub use clause::FsClause;
+pub use context::{FsContextBinding, FsTypingContext};
+pub use declaration::{cont_int, FsTypeDeclaration, FsXtorSig};
+pub use def::FsDef;
 pub use names::{Name, Var};
-pub use program::Prog;
-pub use statement::Statement;
-pub use term::Term;
+pub use program::FsProg;
+pub use statement::FsStatement;
+pub use term::FsTerm;

--- a/lang/core/src/syntax_var/program.rs
+++ b/lang/core/src/syntax_var/program.rs
@@ -1,14 +1,14 @@
 use printer::{DocAllocator, Print};
 
-use super::{Def, TypeDeclaration};
+use super::{FsDef, FsTypeDeclaration};
 
 #[derive(Debug, Clone)]
-pub struct Prog {
-    pub defs: Vec<Def>,
-    pub types: Vec<TypeDeclaration>,
+pub struct FsProg {
+    pub defs: Vec<FsDef>,
+    pub types: Vec<FsTypeDeclaration>,
 }
 
-impl Print for Prog {
+impl Print for FsProg {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,

--- a/lang/core/src/syntax_var/statement/call.rs
+++ b/lang/core/src/syntax_var/statement/call.rs
@@ -1,17 +1,18 @@
 use printer::{DocAllocator, Print};
 
 use crate::{
-    syntax_var::{Name, Statement, Var},
+    syntax_var::{FsStatement, Name, Var},
     traits::substitution::SubstVar,
 };
 
+/// Focused Call
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Call {
+pub struct FsCall {
     pub name: Name,
     pub args: Vec<Var>,
 }
 
-impl Print for Call {
+impl Print for FsCall {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -23,17 +24,17 @@ impl Print for Call {
     }
 }
 
-impl From<Call> for Statement {
-    fn from(value: Call) -> Self {
-        Statement::Call(value)
+impl From<FsCall> for FsStatement {
+    fn from(value: FsCall) -> Self {
+        FsStatement::Call(value)
     }
 }
 
-impl SubstVar for Call {
-    type Target = Call;
+impl SubstVar for FsCall {
+    type Target = FsCall;
 
-    fn subst_sim(self, subst: &[(Var, Var)]) -> Call {
-        Call {
+    fn subst_sim(self, subst: &[(Var, Var)]) -> FsCall {
+        FsCall {
             name: self.name,
             args: self.args.subst_sim(subst),
         }

--- a/lang/core/src/syntax_var/statement/cut.rs
+++ b/lang/core/src/syntax_var/statement/cut.rs
@@ -5,23 +5,24 @@ use printer::{
 
 use crate::{
     syntax::Ty,
-    syntax_var::term::Term,
-    syntax_var::{Statement, Var},
+    syntax_var::term::FsTerm,
+    syntax_var::{FsStatement, Var},
     traits::substitution::SubstVar,
 };
 
 use std::rc::Rc;
 
+/// Focused Cut
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Cut {
+pub struct FsCut {
     pub ty: Ty,
-    pub producer: Rc<Term>,
-    pub consumer: Rc<Term>,
+    pub producer: Rc<FsTerm>,
+    pub consumer: Rc<FsTerm>,
 }
 
-impl Cut {
-    pub fn new<T: Into<Term>, S: Into<Term>>(ty: Ty, prd: T, cns: S) -> Self {
-        Cut {
+impl FsCut {
+    pub fn new<T: Into<FsTerm>, S: Into<FsTerm>>(ty: Ty, prd: T, cns: S) -> Self {
+        FsCut {
             ty,
             producer: Rc::new(prd.into()),
             consumer: Rc::new(cns.into()),
@@ -29,13 +30,13 @@ impl Cut {
     }
 }
 
-impl Print for Cut {
+impl Print for FsCut {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
         alloc: &'a printer::Alloc<'a>,
     ) -> printer::Builder<'a> {
-        let Cut {
+        let FsCut {
             ty: _,
             producer,
             consumer,
@@ -52,17 +53,17 @@ impl Print for Cut {
     }
 }
 
-impl From<Cut> for Statement {
-    fn from(value: Cut) -> Self {
-        Statement::Cut(value)
+impl From<FsCut> for FsStatement {
+    fn from(value: FsCut) -> Self {
+        FsStatement::Cut(value)
     }
 }
 
-impl SubstVar for Cut {
-    type Target = Cut;
+impl SubstVar for FsCut {
+    type Target = FsCut;
 
-    fn subst_sim(self, subst: &[(Var, Var)]) -> Cut {
-        Cut {
+    fn subst_sim(self, subst: &[(Var, Var)]) -> FsCut {
+        FsCut {
             ty: self.ty,
             producer: self.producer.subst_sim(subst),
             consumer: self.consumer.subst_sim(subst),

--- a/lang/core/src/syntax_var/statement/ife.rs
+++ b/lang/core/src/syntax_var/statement/ife.rs
@@ -4,20 +4,21 @@ use printer::{
     DocAllocator, Print,
 };
 
-use crate::syntax_var::{Statement, Var};
+use crate::syntax_var::{FsStatement, Var};
 use crate::traits::substitution::SubstVar;
 
 use std::rc::Rc;
 
+/// Focused IfE
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IfE {
+pub struct FsIfE {
     pub fst: Var,
     pub snd: Var,
-    pub thenc: Rc<Statement>,
-    pub elsec: Rc<Statement>,
+    pub thenc: Rc<FsStatement>,
+    pub elsec: Rc<FsStatement>,
 }
 
-impl Print for IfE {
+impl Print for FsIfE {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -40,17 +41,17 @@ impl Print for IfE {
     }
 }
 
-impl From<IfE> for Statement {
-    fn from(value: IfE) -> Self {
-        Statement::IfE(value)
+impl From<FsIfE> for FsStatement {
+    fn from(value: FsIfE) -> Self {
+        FsStatement::IfE(value)
     }
 }
 
-impl SubstVar for IfE {
-    type Target = IfE;
+impl SubstVar for FsIfE {
+    type Target = FsIfE;
 
-    fn subst_sim(self, subst: &[(Var, Var)]) -> IfE {
-        IfE {
+    fn subst_sim(self, subst: &[(Var, Var)]) -> FsIfE {
+        FsIfE {
             fst: self.fst.subst_sim(subst),
             snd: self.snd.subst_sim(subst),
             thenc: self.thenc.subst_sim(subst),

--- a/lang/core/src/syntax_var/statement/ifl.rs
+++ b/lang/core/src/syntax_var/statement/ifl.rs
@@ -4,20 +4,21 @@ use printer::{
     DocAllocator, Print,
 };
 
-use crate::syntax_var::{Statement, Var};
+use crate::syntax_var::{FsStatement, Var};
 use crate::traits::substitution::SubstVar;
 
 use std::rc::Rc;
 
+/// Focused IfL
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IfL {
+pub struct FsIfL {
     pub fst: Var,
     pub snd: Var,
-    pub thenc: Rc<Statement>,
-    pub elsec: Rc<Statement>,
+    pub thenc: Rc<FsStatement>,
+    pub elsec: Rc<FsStatement>,
 }
 
-impl Print for IfL {
+impl Print for FsIfL {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -40,17 +41,17 @@ impl Print for IfL {
     }
 }
 
-impl From<IfL> for Statement {
-    fn from(value: IfL) -> Self {
-        Statement::IfL(value)
+impl From<FsIfL> for FsStatement {
+    fn from(value: FsIfL) -> Self {
+        FsStatement::IfL(value)
     }
 }
 
-impl SubstVar for IfL {
-    type Target = IfL;
+impl SubstVar for FsIfL {
+    type Target = FsIfL;
 
-    fn subst_sim(self, subst: &[(Var, Var)]) -> IfL {
-        IfL {
+    fn subst_sim(self, subst: &[(Var, Var)]) -> FsIfL {
+        FsIfL {
             fst: self.fst.subst_sim(subst),
             snd: self.snd.subst_sim(subst),
             thenc: self.thenc.subst_sim(subst),

--- a/lang/core/src/syntax_var/statement/ifz.rs
+++ b/lang/core/src/syntax_var/statement/ifz.rs
@@ -4,19 +4,20 @@ use printer::{
     DocAllocator, Print,
 };
 
-use crate::syntax_var::{Statement, Var};
+use crate::syntax_var::{FsStatement, Var};
 use crate::traits::substitution::SubstVar;
 
 use std::rc::Rc;
 
+/// Focused IfZ
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IfZ {
+pub struct FsIfZ {
     pub ifc: Var,
-    pub thenc: Rc<Statement>,
-    pub elsec: Rc<Statement>,
+    pub thenc: Rc<FsStatement>,
+    pub elsec: Rc<FsStatement>,
 }
 
-impl Print for IfZ {
+impl Print for FsIfZ {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -36,17 +37,17 @@ impl Print for IfZ {
     }
 }
 
-impl From<IfZ> for Statement {
-    fn from(value: IfZ) -> Self {
-        Statement::IfZ(value)
+impl From<FsIfZ> for FsStatement {
+    fn from(value: FsIfZ) -> Self {
+        FsStatement::IfZ(value)
     }
 }
 
-impl SubstVar for IfZ {
-    type Target = IfZ;
+impl SubstVar for FsIfZ {
+    type Target = FsIfZ;
 
-    fn subst_sim(self, subst: &[(Var, Var)]) -> IfZ {
-        IfZ {
+    fn subst_sim(self, subst: &[(Var, Var)]) -> FsIfZ {
+        FsIfZ {
             ifc: self.ifc.subst_sim(subst),
             thenc: self.thenc.subst_sim(subst),
             elsec: self.elsec.subst_sim(subst),

--- a/lang/core/src/syntax_var/statement/mod.rs
+++ b/lang/core/src/syntax_var/statement/mod.rs
@@ -19,45 +19,45 @@ pub use ifz::*;
 pub use op::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Statement {
-    Cut(Cut),
-    Op(Op),
-    IfE(IfE),
-    IfL(IfL),
-    IfZ(IfZ),
-    Call(Call),
+pub enum FsStatement {
+    Cut(FsCut),
+    Op(FsOp),
+    IfE(FsIfE),
+    IfL(FsIfL),
+    IfZ(FsIfZ),
+    Call(FsCall),
     Done(),
 }
 
-impl Print for Statement {
+impl Print for FsStatement {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
         alloc: &'a printer::Alloc<'a>,
     ) -> printer::Builder<'a> {
         match self {
-            Statement::Cut(cut) => cut.print(cfg, alloc),
-            Statement::Op(op) => op.print(cfg, alloc),
-            Statement::IfE(ife) => ife.print(cfg, alloc),
-            Statement::IfL(ifl) => ifl.print(cfg, alloc),
-            Statement::IfZ(ifz) => ifz.print(cfg, alloc),
-            Statement::Call(call) => call.print(cfg, alloc),
-            Statement::Done() => alloc.keyword(DONE),
+            FsStatement::Cut(cut) => cut.print(cfg, alloc),
+            FsStatement::Op(op) => op.print(cfg, alloc),
+            FsStatement::IfE(ife) => ife.print(cfg, alloc),
+            FsStatement::IfL(ifl) => ifl.print(cfg, alloc),
+            FsStatement::IfZ(ifz) => ifz.print(cfg, alloc),
+            FsStatement::Call(call) => call.print(cfg, alloc),
+            FsStatement::Done() => alloc.keyword(DONE),
         }
     }
 }
 
-impl SubstVar for Statement {
-    type Target = Statement;
-    fn subst_sim(self, subst: &[(Var, Var)]) -> Statement {
+impl SubstVar for FsStatement {
+    type Target = FsStatement;
+    fn subst_sim(self, subst: &[(Var, Var)]) -> FsStatement {
         match self {
-            Statement::Cut(cut) => cut.subst_sim(subst).into(),
-            Statement::Op(op) => op.subst_sim(subst).into(),
-            Statement::IfE(ife) => ife.subst_sim(subst).into(),
-            Statement::IfL(ifl) => ifl.subst_sim(subst).into(),
-            Statement::IfZ(ifz) => ifz.subst_sim(subst).into(),
-            Statement::Call(call) => call.subst_sim(subst).into(),
-            Statement::Done() => Statement::Done(),
+            FsStatement::Cut(cut) => cut.subst_sim(subst).into(),
+            FsStatement::Op(op) => op.subst_sim(subst).into(),
+            FsStatement::IfE(ife) => ife.subst_sim(subst).into(),
+            FsStatement::IfL(ifl) => ifl.subst_sim(subst).into(),
+            FsStatement::IfZ(ifz) => ifz.subst_sim(subst).into(),
+            FsStatement::Call(call) => call.subst_sim(subst).into(),
+            FsStatement::Done() => FsStatement::Done(),
         }
     }
 }

--- a/lang/core/src/syntax_var/statement/op.rs
+++ b/lang/core/src/syntax_var/statement/op.rs
@@ -5,21 +5,22 @@ use printer::{
 
 use crate::{
     syntax::BinOp,
-    syntax_var::{term::Term, Statement, Var},
+    syntax_var::{term::FsTerm, FsStatement, Var},
     traits::substitution::SubstVar,
 };
 
 use std::rc::Rc;
 
+/// Focused binary operation
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Op {
+pub struct FsOp {
     pub fst: Var,
     pub op: BinOp,
     pub snd: Var,
-    pub continuation: Rc<Term>,
+    pub continuation: Rc<FsTerm>,
 }
 
-impl Print for Op {
+impl Print for FsOp {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -39,17 +40,17 @@ impl Print for Op {
     }
 }
 
-impl From<Op> for Statement {
-    fn from(value: Op) -> Self {
-        Statement::Op(value)
+impl From<FsOp> for FsStatement {
+    fn from(value: FsOp) -> Self {
+        FsStatement::Op(value)
     }
 }
 
-impl SubstVar for Op {
-    type Target = Op;
+impl SubstVar for FsOp {
+    type Target = FsOp;
 
     fn subst_sim(self, subst: &[(Var, Var)]) -> Self::Target {
-        Op {
+        FsOp {
             fst: self.fst.subst_sim(subst),
             op: self.op,
             snd: self.snd.subst_sim(subst),

--- a/lang/core/src/syntax_var/term/literal.rs
+++ b/lang/core/src/syntax_var/term/literal.rs
@@ -1,20 +1,20 @@
 use printer::{DocAllocator, Print};
 
-use super::Term;
+use super::FsTerm;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Literal {
+pub struct FsLiteral {
     pub lit: i64,
 }
 
-impl Literal {
+impl FsLiteral {
     #[must_use]
     pub fn new(lit: i64) -> Self {
-        Literal { lit }
+        FsLiteral { lit }
     }
 }
 
-impl Print for Literal {
+impl Print for FsLiteral {
     fn print<'a>(
         &'a self,
         _cfg: &printer::PrintCfg,
@@ -24,8 +24,8 @@ impl Print for Literal {
     }
 }
 
-impl From<Literal> for Term {
-    fn from(value: Literal) -> Self {
-        Term::Literal(value)
+impl From<FsLiteral> for FsTerm {
+    fn from(value: FsLiteral) -> Self {
+        FsTerm::Literal(value)
     }
 }

--- a/lang/core/src/syntax_var/term/mod.rs
+++ b/lang/core/src/syntax_var/term/mod.rs
@@ -8,46 +8,46 @@ pub mod xcase;
 pub mod xtor;
 pub mod xvar;
 
-pub use literal::Literal;
-pub use mu::Mu;
-pub use xcase::XCase;
-pub use xtor::Xtor;
-pub use xvar::XVar;
+pub use literal::FsLiteral;
+pub use mu::FsMu;
+pub use xcase::FsXCase;
+pub use xtor::FsXtor;
+pub use xvar::FsXVar;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Term {
-    XVar(XVar),
-    Literal(Literal),
-    Mu(Mu),
-    Xtor(Xtor),
-    XCase(XCase),
+pub enum FsTerm {
+    XVar(FsXVar),
+    Literal(FsLiteral),
+    Mu(FsMu),
+    Xtor(FsXtor),
+    XCase(FsXCase),
 }
 
-impl Print for Term {
+impl Print for FsTerm {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
         alloc: &'a printer::Alloc<'a>,
     ) -> printer::Builder<'a> {
         match self {
-            Term::XVar(var) => var.print(cfg, alloc),
-            Term::Literal(lit) => lit.print(cfg, alloc),
-            Term::Mu(mu) => mu.print(cfg, alloc),
-            Term::Xtor(xtor) => xtor.print(cfg, alloc),
-            Term::XCase(xcase) => xcase.print(cfg, alloc),
+            FsTerm::XVar(var) => var.print(cfg, alloc),
+            FsTerm::Literal(lit) => lit.print(cfg, alloc),
+            FsTerm::Mu(mu) => mu.print(cfg, alloc),
+            FsTerm::Xtor(xtor) => xtor.print(cfg, alloc),
+            FsTerm::XCase(xcase) => xcase.print(cfg, alloc),
         }
     }
 }
 
-impl SubstVar for Term {
-    type Target = Term;
+impl SubstVar for FsTerm {
+    type Target = FsTerm;
     fn subst_sim(self, subst: &[(Var, Var)]) -> Self::Target {
         match self {
-            Term::XVar(var) => var.subst_sim(subst).into(),
-            Term::Literal(lit) => Term::Literal(lit),
-            Term::Mu(mu) => mu.subst_sim(subst).into(),
-            Term::Xtor(xtor) => xtor.subst_sim(subst).into(),
-            Term::XCase(xcase) => xcase.subst_sim(subst).into(),
+            FsTerm::XVar(var) => var.subst_sim(subst).into(),
+            FsTerm::Literal(lit) => FsTerm::Literal(lit),
+            FsTerm::Mu(mu) => mu.subst_sim(subst).into(),
+            FsTerm::Xtor(xtor) => xtor.subst_sim(subst).into(),
+            FsTerm::XCase(xcase) => xcase.subst_sim(subst).into(),
         }
     }
 }

--- a/lang/core/src/syntax_var/term/mu.rs
+++ b/lang/core/src/syntax_var/term/mu.rs
@@ -1,8 +1,8 @@
 use printer::{theme::ThemeExt, tokens::DOT, DocAllocator, Print};
 
-use super::Term;
+use super::FsTerm;
 use crate::{
-    syntax_var::{Chirality, Statement, Var},
+    syntax_var::{Chirality, FsStatement, Var},
     traits::substitution::SubstVar,
 };
 
@@ -12,25 +12,25 @@ use std::rc::Rc;
 /// - A Mu abstraction if `chi = Prd`
 /// - A TildeMu abstraction if `chi = Cns`
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Mu {
+pub struct FsMu {
     pub chi: Chirality,
     pub variable: Var,
-    pub statement: Rc<Statement>,
+    pub statement: Rc<FsStatement>,
 }
 
-impl Mu {
+impl FsMu {
     /// Create a new Mu abstraction
     #[allow(clippy::self_named_constructors)]
-    pub fn mu<T: Into<Statement>>(var: &str, statement: T) -> Self {
-        Mu {
+    pub fn mu<T: Into<FsStatement>>(var: &str, statement: T) -> Self {
+        FsMu {
             chi: Chirality::Prd,
             variable: var.to_string(),
             statement: Rc::new(statement.into()),
         }
     }
     /// Create a new TildeMu abstraction
-    pub fn tilde_mu<T: Into<Statement>>(var: &str, statement: T) -> Self {
-        Mu {
+    pub fn tilde_mu<T: Into<FsStatement>>(var: &str, statement: T) -> Self {
+        FsMu {
             chi: Chirality::Cns,
             variable: var.to_string(),
             statement: Rc::new(statement.into()),
@@ -38,7 +38,7 @@ impl Mu {
     }
 }
 
-impl Print for Mu {
+impl Print for FsMu {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -62,16 +62,16 @@ impl Print for Mu {
     }
 }
 
-impl From<Mu> for Term {
-    fn from(value: Mu) -> Self {
-        Term::Mu(value)
+impl From<FsMu> for FsTerm {
+    fn from(value: FsMu) -> Self {
+        FsTerm::Mu(value)
     }
 }
 
-impl SubstVar for Mu {
-    type Target = Mu;
-    fn subst_sim(self, subst: &[(Var, Var)]) -> Mu {
-        Mu {
+impl SubstVar for FsMu {
+    type Target = FsMu;
+    fn subst_sim(self, subst: &[(Var, Var)]) -> FsMu {
+        FsMu {
             chi: self.chi,
             variable: self.variable,
             statement: self.statement.subst_sim(subst),

--- a/lang/core/src/syntax_var/term/xcase.rs
+++ b/lang/core/src/syntax_var/term/xcase.rs
@@ -1,18 +1,18 @@
 use printer::{theme::ThemeExt, tokens::CASE, DocAllocator, Print};
 
-use super::Term;
+use super::FsTerm;
 use crate::{
     syntax_var::clause::print_clauses,
-    syntax_var::{Clause, Var},
+    syntax_var::{FsClause, Var},
     traits::substitution::SubstVar,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct XCase {
-    pub clauses: Vec<Clause>,
+pub struct FsXCase {
+    pub clauses: Vec<FsClause>,
 }
 
-impl Print for XCase {
+impl Print for FsXCase {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -25,16 +25,16 @@ impl Print for XCase {
     }
 }
 
-impl From<XCase> for Term {
-    fn from(value: XCase) -> Self {
-        Term::XCase(value)
+impl From<FsXCase> for FsTerm {
+    fn from(value: FsXCase) -> Self {
+        FsTerm::XCase(value)
     }
 }
 
-impl SubstVar for XCase {
-    type Target = XCase;
+impl SubstVar for FsXCase {
+    type Target = FsXCase;
     fn subst_sim(self, subst: &[(Var, Var)]) -> Self::Target {
-        XCase {
+        FsXCase {
             clauses: self.clauses.subst_sim(subst),
         }
     }

--- a/lang/core/src/syntax_var/term/xtor.rs
+++ b/lang/core/src/syntax_var/term/xtor.rs
@@ -1,18 +1,18 @@
 use printer::{DocAllocator, Print};
 
-use super::Term;
+use super::FsTerm;
 use crate::{
     syntax_var::{Name, Var},
     traits::substitution::SubstVar,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Xtor {
+pub struct FsXtor {
     pub id: Name,
     pub args: Vec<Var>,
 }
 
-impl Print for Xtor {
+impl Print for FsXtor {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
@@ -27,16 +27,16 @@ impl Print for Xtor {
     }
 }
 
-impl From<Xtor> for Term {
-    fn from(value: Xtor) -> Self {
-        Term::Xtor(value)
+impl From<FsXtor> for FsTerm {
+    fn from(value: FsXtor) -> Self {
+        FsTerm::Xtor(value)
     }
 }
 
-impl SubstVar for Xtor {
-    type Target = Xtor;
+impl SubstVar for FsXtor {
+    type Target = FsXtor;
     fn subst_sim(self, subst: &[(Var, Var)]) -> Self::Target {
-        Xtor {
+        FsXtor {
             id: self.id,
             args: self.args.subst_sim(subst),
         }

--- a/lang/core/src/syntax_var/term/xvar.rs
+++ b/lang/core/src/syntax_var/term/xvar.rs
@@ -1,6 +1,6 @@
 use printer::{DocAllocator, Print};
 
-use super::Term;
+use super::FsTerm;
 use crate::{
     syntax_var::{Chirality, Var},
     traits::substitution::SubstVar,
@@ -10,30 +10,30 @@ use crate::{
 /// - A variable if `T = Prd`
 /// - A covariable if `T = Cns`
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct XVar {
+pub struct FsXVar {
     pub chi: Chirality,
     pub var: Var,
 }
 
-impl XVar {
+impl FsXVar {
     /// Create a new variable with the given name.
     #[must_use]
     pub fn var(name: &str) -> Self {
-        XVar {
+        FsXVar {
             chi: Chirality::Prd,
             var: name.to_string(),
         }
     }
     #[must_use]
     pub fn covar(name: &str) -> Self {
-        XVar {
+        FsXVar {
             chi: Chirality::Cns,
             var: name.to_string(),
         }
     }
 }
 
-impl Print for XVar {
+impl Print for FsXVar {
     fn print<'a>(
         &'a self,
         _cfg: &printer::PrintCfg,
@@ -43,16 +43,16 @@ impl Print for XVar {
     }
 }
 
-impl From<XVar> for Term {
-    fn from(value: XVar) -> Self {
-        Term::XVar(value)
+impl From<FsXVar> for FsTerm {
+    fn from(value: FsXVar) -> Self {
+        FsTerm::XVar(value)
     }
 }
 
-impl SubstVar for XVar {
-    type Target = XVar;
+impl SubstVar for FsXVar {
+    type Target = FsXVar;
 
-    fn subst_sim(mut self, subst: &[(Var, Var)]) -> XVar {
+    fn subst_sim(mut self, subst: &[(Var, Var)]) -> FsXVar {
         match subst.iter().find(|(old, _)| *old == self.var) {
             None => self,
             Some((_, new)) => {

--- a/lang/core/src/traits/focus.rs
+++ b/lang/core/src/traits/focus.rs
@@ -60,23 +60,23 @@ impl<T: Focusing> Focusing for Vec<T> {
 }
 
 pub type Continuation =
-    Box<dyn FnOnce(crate::syntax_var::Name, &mut FocusingState) -> crate::syntax_var::Statement>;
+    Box<dyn FnOnce(crate::syntax_var::Name, &mut FocusingState) -> crate::syntax_var::FsStatement>;
 pub type ContinuationVec = Box<
     dyn FnOnce(
         VecDeque<crate::syntax_var::Name>,
         &mut FocusingState,
-    ) -> crate::syntax_var::Statement,
+    ) -> crate::syntax_var::FsStatement,
 >;
 
 pub trait Bind: Sized {
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::Statement;
+    fn bind(self, k: Continuation, state: &mut FocusingState) -> crate::syntax_var::FsStatement;
 }
 
 pub fn bind_many(
     mut args: VecDeque<SubstitutionBinding>,
     k: ContinuationVec,
     state: &mut FocusingState,
-) -> crate::syntax_var::Statement {
+) -> crate::syntax_var::FsStatement {
     match args.pop_front() {
         None => k(VecDeque::new(), state),
         Some(SubstitutionBinding::ProducerBinding(prd)) => prd.bind(

--- a/lang/core2axcut/src/clause.rs
+++ b/lang/core2axcut/src/clause.rs
@@ -1,17 +1,17 @@
-use core::syntax_var::{Clause, TypeDeclaration, Var};
+use core::syntax_var::{FsClause, FsTypeDeclaration, Var};
 
 use crate::context::translate_context;
 use crate::traits::Shrinking;
 
 use std::collections::HashSet;
 
-impl Shrinking for Clause {
+impl Shrinking for FsClause {
     type Target = axcut::syntax::Clause;
 
     fn shrink(
         self,
         used_vars: &mut HashSet<Var>,
-        types: &[TypeDeclaration],
+        types: &[FsTypeDeclaration],
     ) -> axcut::syntax::Clause {
         axcut::syntax::Clause {
             xtor: self.xtor,

--- a/lang/core2axcut/src/context.rs
+++ b/lang/core2axcut/src/context.rs
@@ -6,7 +6,7 @@ use crate::types::translate_ty;
 
 #[must_use]
 pub fn translate_binding(
-    binding: core::syntax_var::ContextBinding,
+    binding: core::syntax_var::FsContextBinding,
 ) -> axcut::syntax::ContextBinding {
     if binding.ty == Ty::Int() {
         if binding.chi == Chirality::Prd {
@@ -31,6 +31,8 @@ pub fn translate_binding(
     }
 }
 
-pub fn translate_context(context: core::syntax_var::TypingContext) -> axcut::syntax::TypingContext {
+pub fn translate_context(
+    context: core::syntax_var::FsTypingContext,
+) -> axcut::syntax::TypingContext {
     context.into_iter().map(translate_binding).collect()
 }

--- a/lang/core2axcut/src/declaration.rs
+++ b/lang/core2axcut/src/declaration.rs
@@ -1,7 +1,7 @@
 use crate::context::translate_context;
 
 #[must_use]
-pub fn translate_sig(sig: core::syntax_var::XtorSig) -> axcut::syntax::XtorSig {
+pub fn translate_sig(sig: core::syntax_var::FsXtorSig) -> axcut::syntax::XtorSig {
     axcut::syntax::XtorSig {
         name: sig.name,
         args: translate_context(sig.args),
@@ -9,7 +9,7 @@ pub fn translate_sig(sig: core::syntax_var::XtorSig) -> axcut::syntax::XtorSig {
 }
 
 pub fn translate_declaration(
-    declaration: core::syntax_var::TypeDeclaration,
+    declaration: core::syntax_var::FsTypeDeclaration,
 ) -> axcut::syntax::TypeDeclaration {
     axcut::syntax::TypeDeclaration {
         name: declaration.name,

--- a/lang/core2axcut/src/def.rs
+++ b/lang/core2axcut/src/def.rs
@@ -1,9 +1,9 @@
-use core::syntax_var::{Def, TypeDeclaration};
+use core::syntax_var::{FsDef, FsTypeDeclaration};
 
 use crate::context::translate_context;
 use crate::traits::Shrinking;
 
-pub fn shrink(mut def: Def, types: &[TypeDeclaration]) -> axcut::syntax::Def {
+pub fn shrink(mut def: FsDef, types: &[FsTypeDeclaration]) -> axcut::syntax::Def {
     axcut::syntax::Def {
         name: def.name,
         context: translate_context(def.context),

--- a/lang/core2axcut/src/program.rs
+++ b/lang/core2axcut/src/program.rs
@@ -3,7 +3,7 @@ use core::syntax_var::cont_int;
 use crate::declaration::translate_declaration;
 
 #[must_use]
-pub fn translate_prog(mut program: core::syntax_var::Prog) -> axcut::syntax::Prog {
+pub fn translate_prog(mut program: core::syntax_var::FsProg) -> axcut::syntax::Prog {
     let cont_int = cont_int();
     for typ in &program.types {
         assert!(

--- a/lang/core2axcut/src/statement/call.rs
+++ b/lang/core2axcut/src/statement/call.rs
@@ -1,16 +1,16 @@
-use core::syntax_var::{statement::Call, TypeDeclaration, Var};
+use core::syntax_var::{statement::FsCall, FsTypeDeclaration, Var};
 
 use crate::traits::Shrinking;
 
 use std::collections::HashSet;
 
-impl Shrinking for Call {
+impl Shrinking for FsCall {
     type Target = axcut::syntax::Statement;
 
     fn shrink(
         self,
         _used_vars: &mut HashSet<Var>,
-        _types: &[TypeDeclaration],
+        _types: &[FsTypeDeclaration],
     ) -> axcut::syntax::Statement {
         axcut::syntax::Statement::Call(axcut::syntax::statements::Call {
             label: self.name,

--- a/lang/core2axcut/src/statement/ife.rs
+++ b/lang/core2axcut/src/statement/ife.rs
@@ -1,16 +1,16 @@
-use core::syntax_var::{statement::IfE, TypeDeclaration, Var};
+use core::syntax_var::{statement::FsIfE, FsTypeDeclaration, Var};
 
 use crate::traits::Shrinking;
 
 use std::collections::HashSet;
 
-impl Shrinking for IfE {
+impl Shrinking for FsIfE {
     type Target = axcut::syntax::Statement;
 
     fn shrink(
         self,
         used_vars: &mut HashSet<Var>,
-        types: &[TypeDeclaration],
+        types: &[FsTypeDeclaration],
     ) -> axcut::syntax::Statement {
         axcut::syntax::Statement::IfE(axcut::syntax::statements::IfE {
             fst: self.fst,

--- a/lang/core2axcut/src/statement/ifl.rs
+++ b/lang/core2axcut/src/statement/ifl.rs
@@ -1,16 +1,16 @@
-use core::syntax_var::{statement::IfL, TypeDeclaration, Var};
+use core::syntax_var::{statement::FsIfL, FsTypeDeclaration, Var};
 
 use crate::traits::Shrinking;
 
 use std::collections::HashSet;
 
-impl Shrinking for IfL {
+impl Shrinking for FsIfL {
     type Target = axcut::syntax::Statement;
 
     fn shrink(
         self,
         used_vars: &mut HashSet<Var>,
-        types: &[TypeDeclaration],
+        types: &[FsTypeDeclaration],
     ) -> axcut::syntax::Statement {
         axcut::syntax::Statement::IfL(axcut::syntax::statements::IfL {
             fst: self.fst,

--- a/lang/core2axcut/src/statement/ifz.rs
+++ b/lang/core2axcut/src/statement/ifz.rs
@@ -1,16 +1,16 @@
-use core::syntax_var::{statement::IfZ, TypeDeclaration, Var};
+use core::syntax_var::{statement::FsIfZ, FsTypeDeclaration, Var};
 
 use crate::traits::Shrinking;
 
 use std::collections::HashSet;
 
-impl Shrinking for IfZ {
+impl Shrinking for FsIfZ {
     type Target = axcut::syntax::Statement;
 
     fn shrink(
         self,
         used_vars: &mut HashSet<Var>,
-        types: &[TypeDeclaration],
+        types: &[FsTypeDeclaration],
     ) -> axcut::syntax::Statement {
         axcut::syntax::Statement::IfZ(axcut::syntax::statements::IfZ {
             ifc: self.ifc,

--- a/lang/core2axcut/src/statement/mod.rs
+++ b/lang/core2axcut/src/statement/mod.rs
@@ -1,5 +1,5 @@
 use crate::traits::Shrinking;
-use core::syntax_var::{Statement, TypeDeclaration, Var};
+use core::syntax_var::{FsStatement, FsTypeDeclaration, Var};
 
 use std::collections::HashSet;
 
@@ -10,22 +10,22 @@ pub mod ifl;
 pub mod ifz;
 pub mod op;
 
-impl Shrinking for Statement {
+impl Shrinking for FsStatement {
     type Target = axcut::syntax::Statement;
 
     fn shrink(
         self,
         used_vars: &mut HashSet<Var>,
-        types: &[TypeDeclaration],
+        types: &[FsTypeDeclaration],
     ) -> axcut::syntax::Statement {
         match self {
-            Statement::Cut(cut) => cut.shrink(used_vars, types),
-            Statement::Op(op) => op.shrink(used_vars, types),
-            Statement::IfE(ife) => ife.shrink(used_vars, types),
-            Statement::IfL(ifl) => ifl.shrink(used_vars, types),
-            Statement::IfZ(ifz) => ifz.shrink(used_vars, types),
-            Statement::Call(fun) => fun.shrink(used_vars, types),
-            Statement::Done() => axcut::syntax::Statement::Done,
+            FsStatement::Cut(cut) => cut.shrink(used_vars, types),
+            FsStatement::Op(op) => op.shrink(used_vars, types),
+            FsStatement::IfE(ife) => ife.shrink(used_vars, types),
+            FsStatement::IfL(ifl) => ifl.shrink(used_vars, types),
+            FsStatement::IfZ(ifz) => ifz.shrink(used_vars, types),
+            FsStatement::Call(fun) => fun.shrink(used_vars, types),
+            FsStatement::Done() => axcut::syntax::Statement::Done,
         }
     }
 }

--- a/lang/core2axcut/src/statement/op.rs
+++ b/lang/core2axcut/src/statement/op.rs
@@ -1,9 +1,9 @@
 use core::syntax_var::{
     cont_int,
-    statement::Op,
-    term::{Mu, Term, XVar},
+    statement::FsOp,
+    term::{FsMu, FsTerm, FsXVar},
     Chirality::Cns,
-    Statement, TypeDeclaration, Var,
+    FsStatement, FsTypeDeclaration, Var,
 };
 use core::traits::free_vars::fresh_var;
 
@@ -12,21 +12,21 @@ use crate::traits::Shrinking;
 
 use std::{collections::HashSet, rc::Rc};
 
-impl Shrinking for Op {
+impl Shrinking for FsOp {
     type Target = axcut::syntax::Statement;
 
     fn shrink(
         self,
         used_vars: &mut HashSet<Var>,
-        types: &[TypeDeclaration],
+        types: &[FsTypeDeclaration],
     ) -> axcut::syntax::Statement {
         match Rc::unwrap_or_clone(self.continuation) {
-            Term::Mu(Mu {
+            FsTerm::Mu(FsMu {
                 chi: Cns,
                 variable,
                 statement,
             }) => {
-                let case = if *statement == Statement::Done() {
+                let case = if *statement == FsStatement::Done() {
                     Rc::new(axcut::syntax::Statement::Return(
                         axcut::syntax::statements::Return {
                             var: variable.clone(),
@@ -43,7 +43,7 @@ impl Shrinking for Op {
                     case,
                 })
             }
-            Term::XVar(XVar { chi: Cns, var }) => {
+            FsTerm::XVar(FsXVar { chi: Cns, var }) => {
                 let fresh_var = fresh_var(used_vars, "x");
                 axcut::syntax::Statement::Op(axcut::syntax::statements::Op {
                     fst: self.fst,

--- a/lang/core2axcut/src/traits.rs
+++ b/lang/core2axcut/src/traits.rs
@@ -1,4 +1,4 @@
-use core::syntax_var::{TypeDeclaration, Var};
+use core::syntax_var::{FsTypeDeclaration, Var};
 
 use std::collections::HashSet;
 use std::rc::Rc;
@@ -6,19 +6,19 @@ use std::rc::Rc;
 /// This assumes all variable bindings to be unique and maintains this invariant.
 pub trait Shrinking {
     type Target;
-    fn shrink(self, used_vars: &mut HashSet<Var>, types: &[TypeDeclaration]) -> Self::Target;
+    fn shrink(self, used_vars: &mut HashSet<Var>, types: &[FsTypeDeclaration]) -> Self::Target;
 }
 
 impl<T: Shrinking + Clone> Shrinking for Rc<T> {
     type Target = Rc<T::Target>;
-    fn shrink(self, used_vars: &mut HashSet<Var>, types: &[TypeDeclaration]) -> Self::Target {
+    fn shrink(self, used_vars: &mut HashSet<Var>, types: &[FsTypeDeclaration]) -> Self::Target {
         Rc::new(Rc::unwrap_or_clone(self).shrink(used_vars, types))
     }
 }
 
 impl<T: Shrinking> Shrinking for Vec<T> {
     type Target = Vec<T::Target>;
-    fn shrink(self, used_vars: &mut HashSet<Var>, types: &[TypeDeclaration]) -> Self::Target {
+    fn shrink(self, used_vars: &mut HashSet<Var>, types: &[FsTypeDeclaration]) -> Self::Target {
         self.into_iter()
             .map(|element| element.shrink(used_vars, types))
             .collect()

--- a/lang/driver/src/lib.rs
+++ b/lang/driver/src/lib.rs
@@ -35,7 +35,7 @@ pub struct Driver {
     /// Compiled to core, but not yet focused
     compiled: HashMap<PathBuf, core::syntax::Prog>,
     /// Compiled to core and focused
-    focused: HashMap<PathBuf, core::syntax_var::Prog>,
+    focused: HashMap<PathBuf, core::syntax_var::FsProg>,
     /// Compiled to non-linearized axcut
     shrunk: HashMap<PathBuf, axcut::syntax::Prog>,
     /// Compiled to linearized axcut
@@ -150,7 +150,7 @@ impl Driver {
     }
 
     /// Return the focused version of the Core code.
-    pub fn focused(&mut self, path: &PathBuf) -> Result<core::syntax_var::Prog, DriverError> {
+    pub fn focused(&mut self, path: &PathBuf) -> Result<core::syntax_var::FsProg, DriverError> {
         // Check for cache hit.
         if let Some(res) = self.focused.get(path) {
             return Ok(res.clone());


### PR DESCRIPTION
In order to remove further duplication I want to move the syntax together with the focused subsyntax into the same module. In order for this to be possible I added a `Fs` prefix which stands for `focused` to everything in `syntax_var`.