### PR TITLE
Do not allow duplicate binders within parameters lists

### DIFF
--- a/lang/fun/src/syntax/declarations/definition.rs
+++ b/lang/fun/src/syntax/declarations/definition.rs
@@ -7,6 +7,7 @@ use printer::{
 };
 
 use crate::{
+    parser::util::ToMiette,
     syntax::{context::TypingContext, terms::Term, types::Ty, Name},
     typing::{check::Check, errors::Error, symbol_table::SymbolTable},
 };
@@ -28,6 +29,8 @@ pub struct Definition {
 impl Definition {
     pub fn check(self, symbol_table: &SymbolTable) -> Result<Definition, Error> {
         self.context.check(symbol_table)?;
+        self.context
+            .no_dups(&self.span.to_miette(), self.name.clone())?;
         self.ret_ty.check(symbol_table)?;
         let body_checked = self.body.check(symbol_table, &self.context, &self.ret_ty)?;
         Ok(Definition {

--- a/lang/fun/src/syntax/terms/case.rs
+++ b/lang/fun/src/syntax/terms/case.rs
@@ -89,6 +89,8 @@ impl Check for Case {
             }
             match symbol_table.ctors.get(&case.xtor) {
                 Some(ctor_ctx) => {
+                    case.context
+                        .no_dups(&case.span.to_miette(), case.xtor.clone())?;
                     case.context.compare_to(&case.span.to_miette(), ctor_ctx)?;
 
                     let mut new_context = context.clone();

--- a/lang/fun/src/syntax/terms/cocase.rs
+++ b/lang/fun/src/syntax/terms/cocase.rs
@@ -106,6 +106,9 @@ impl Check for Cocase {
             };
             cocase
                 .context
+                .no_dups(&cocase.span.to_miette(), cocase.xtor.clone())?;
+            cocase
+                .context
                 .compare_to(&cocase.span.to_miette(), dtor_ctx)?;
 
             let mut new_context = context.clone();

--- a/lang/fun/src/typing/errors.rs
+++ b/lang/fun/src/typing/errors.rs
@@ -120,4 +120,20 @@ pub enum Error {
         span: SourceSpan,
         dtor: String,
     },
+    #[error("{var} is bound multiple times in parameter list of {name}.")]
+    #[diagnostic(code("T-018"))]
+    VarBoundMultipleTimes {
+        #[label]
+        span: SourceSpan,
+        var: Variable,
+        name: Name,
+    },
+    #[error("{covar} is bound multiple times in parameter list {name}.")]
+    #[diagnostic(code("T-019"))]
+    CovarBoundMultipleTimes {
+        #[label]
+        span: SourceSpan,
+        covar: Covariable,
+        name: Name,
+    },
 }


### PR DESCRIPTION
So far we did not check whether a variable was bound multiple times in the same parameter list. That is

```
def foo(a: Int, a: Int) = ...
```

and 

```
case {
    K(a: Int, a: Int) => ...
}
```

were allowed. But I think this shouldn't be allowed, because the first binding can never be used and hence this makes no sense.