### PR TITLE
Add codespans for typing contexts in Fun

### DIFF
--- a/lang/fun/src/parser/fun.lalrpop
+++ b/lang/fun/src/parser/fun.lalrpop
@@ -172,8 +172,8 @@ Destructor: Destructor = {
 Clause: Clause<Name> = {
     <l: @L> <xtor: XtorName> <context: Parens<Context>> "=>" <rhs: Term> <r: @R> =>
         Clause { span: span(l, r), xtor, context, rhs, },
-    <l: @L> <xtor: XtorName> "=>" <rhs: Term> <r: @R> =>
-        Clause { span: span(l, r), xtor, context: TypingContext { bindings: vec![], }, rhs, },
+    <l: @L> <xtor: XtorName> <lc: @L> <rc: @R> "=>" <rhs: Term> <r: @R> =>
+        Clause { span: span(l, r), xtor, context: TypingContext { span: span(lc, rc), bindings: vec![], }, rhs, },
 }
 
 Case: Case = {
@@ -212,7 +212,7 @@ Binding: ContextBinding = {
 }
 
 pub Context : TypingContext = {
-    <bindings: Comma<Binding>> => TypingContext { bindings, },
+    <l: @L> <bindings: Comma<Binding>> <r: @R> => TypingContext { span: span(l, r), bindings, },
 }
 
 // Types
@@ -274,30 +274,30 @@ pub Term: Term = {
 //
 
 Ctor: CtorSig = {
-    <l: @L> <name: XtorName> <args: OptParenthesizedArgs<Binding>> <r: @R> =>
+    <l: @L> <name: XtorName> <lc: @L> <args: OptParenthesizedArgs<Binding>> <r: @R> =>
         CtorSig{
             span: span(l, r),
             name,
-            args: TypingContext { bindings: args, },
+            args: TypingContext { span: span(lc, r), bindings: args, },
         }
 }
 
 Dtor:DtorSig = {
-    <l: @L> <name: XtorName> <args: OptParenthesizedArgs<Binding>> ":" <cont_ty: Ty> <r: @R> =>
+    <l: @L> <name: XtorName> <lc: @L> <args: OptParenthesizedArgs<Binding>> <rc: @R> ":" <cont_ty: Ty> <r: @R> =>
         DtorSig{
             span: span(l, r),
             name,
-            args: TypingContext { bindings: args, },
+            args: TypingContext { span: span(lc, rc), bindings: args, },
             cont_ty,
         }
 }
 
 Def: Definition = {
-    <l: @L> "def" <name: Variable> <context: OptParenthesizedArgs<Binding>> ":" <ret_ty: Ty> ":=" <body: Term> ";" <r: @R> =>
+    <l: @L> "def" <name: Variable> <lc: @L> <context: OptParenthesizedArgs<Binding>> <rc: @R> ":" <ret_ty: Ty> ":=" <body: Term> ";" <r: @R> =>
         Definition {
             span: span(l, r),
             name,
-            context: TypingContext { bindings: context, },
+            context: TypingContext { span: span(lc, rc), bindings: context, },
             body,
             ret_ty,
         }

--- a/lang/fun/src/parser/mod.rs
+++ b/lang/fun/src/parser/mod.rs
@@ -85,6 +85,7 @@ mod parser_tests {
     fn parse_ctx() {
         let parser = fun::ContextParser::new();
         let expected = TypingContext {
+            span: Span::default(),
             bindings: vec![
                 ContextBinding::TypedVar {
                     var: "x".to_owned(),
@@ -111,12 +112,16 @@ mod parser_tests {
                         CtorSig {
                             span: Span::default(),
                             name: "Nil".to_owned(),
-                            args: TypingContext { bindings: vec![] },
+                            args: TypingContext {
+                                span: Span::default(),
+                                bindings: vec![],
+                            },
                         },
                         CtorSig {
                             span: Span::default(),
                             name: "Cons".to_owned(),
                             args: TypingContext {
+                                span: Span::default(),
                                 bindings: vec![
                                     ContextBinding::TypedVar {
                                         var: "x".to_owned(),
@@ -139,13 +144,19 @@ mod parser_tests {
                         DtorSig {
                             span: Span::default(),
                             name: "Hd".to_owned(),
-                            args: TypingContext { bindings: vec![] },
+                            args: TypingContext {
+                                span: Span::default(),
+                                bindings: vec![],
+                            },
                             cont_ty: Ty::mk_int(),
                         },
                         DtorSig {
                             span: Span::default(),
                             name: "Tl".to_owned(),
-                            args: TypingContext { bindings: vec![] },
+                            args: TypingContext {
+                                span: Span::default(),
+                                bindings: vec![],
+                            },
                             cont_ty: Ty::mk_decl("StreamInt"),
                         },
                     ],
@@ -154,7 +165,10 @@ mod parser_tests {
                 Definition {
                     span: Span::default(),
                     name: "main".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     body: Lit::mk(1).into(),
                     ret_ty: Ty::mk_int(),
                 }

--- a/lang/fun/src/syntax/declarations/codata_declaration.rs
+++ b/lang/fun/src/syntax/declarations/codata_declaration.rs
@@ -120,13 +120,19 @@ mod codata_declaration_tests {
                 DtorSig {
                     span: Span::default(),
                     name: "Hd".to_owned(),
-                    args: TypingContext { bindings: vec![] },
+                    args: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     cont_ty: Ty::mk_int(),
                 },
                 DtorSig {
                     span: Span::default(),
                     name: "Tl".to_owned(),
-                    args: TypingContext { bindings: vec![] },
+                    args: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     cont_ty: Ty::mk_decl("StreamInt"),
                 },
             ],

--- a/lang/fun/src/syntax/declarations/data_declaration.rs
+++ b/lang/fun/src/syntax/declarations/data_declaration.rs
@@ -115,12 +115,16 @@ mod data_declaration_tests {
         let nil = CtorSig {
             span: Span::default(),
             name: "Nil".to_owned(),
-            args: TypingContext { bindings: vec![] },
+            args: TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
         };
         let cons = CtorSig {
             span: Span::default(),
             name: "Cons".to_owned(),
             args: TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),

--- a/lang/fun/src/syntax/declarations/definition.rs
+++ b/lang/fun/src/syntax/declarations/definition.rs
@@ -7,7 +7,6 @@ use printer::{
 };
 
 use crate::{
-    parser::util::ToMiette,
     syntax::{context::TypingContext, terms::Term, types::Ty, Name},
     typing::{check::Check, errors::Error, symbol_table::SymbolTable},
 };
@@ -29,8 +28,7 @@ pub struct Definition {
 impl Definition {
     pub fn check(self, symbol_table: &SymbolTable) -> Result<Definition, Error> {
         self.context.check(symbol_table)?;
-        self.context
-            .no_dups(&self.span.to_miette(), self.name.clone())?;
+        self.context.no_dups(self.name.clone())?;
         self.ret_ty.check(symbol_table)?;
         let body_checked = self.body.check(symbol_table, &self.context, &self.ret_ty)?;
         Ok(Definition {
@@ -96,7 +94,10 @@ mod definition_tests {
         Definition {
             span: Span::default(),
             name: "x".to_string(),
-            context: TypingContext { bindings: vec![] },
+            context: TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             body: Term::Lit(Lit::mk(4)),
             ret_ty: Ty::mk_int(),
         }
@@ -123,7 +124,10 @@ mod definition_tests {
         Definition {
             span: Span::default(),
             name: "main".to_owned(),
-            context: TypingContext { bindings: vec![] },
+            context: TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             ret_ty: Ty::mk_decl("ListInt"),
             body: Constructor {
                 span: Span::default(),
@@ -154,12 +158,16 @@ mod definition_tests {
                 CtorSig {
                     span: Span::default(),
                     name: "Nil".to_owned(),
-                    args: TypingContext { bindings: vec![] },
+                    args: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                 },
                 CtorSig {
                     span: Span::default(),
                     name: "Cons".to_owned(),
                     args: TypingContext {
+                        span: Span::default(),
                         bindings: vec![
                             ContextBinding::TypedVar {
                                 var: "x".to_owned(),
@@ -184,7 +192,10 @@ mod definition_tests {
         let expected = Definition {
             span: Span::default(),
             name: "main".to_owned(),
-            context: TypingContext { bindings: vec![] },
+            context: TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             ret_ty: Ty::mk_decl("ListInt"),
             body: Constructor {
                 span: Span::default(),

--- a/lang/fun/src/syntax/declarations/mod.rs
+++ b/lang/fun/src/syntax/declarations/mod.rs
@@ -161,7 +161,10 @@ mod module_tests {
             declarations: vec![Definition {
                 span: Span::default(),
                 name: "x".to_string(),
-                context: TypingContext { bindings: vec![] },
+                context: TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 body: Term::Lit(Lit::mk(4)),
                 ret_ty: Ty::mk_int(),
             }
@@ -210,6 +213,7 @@ mod module_tests {
                 span: Span::default(),
                 name: "f".to_string(),
                 context: TypingContext {
+                    span: Span::default(),
                     bindings: vec![
                         ContextBinding::TypedVar {
                             var: "x".to_string(),
@@ -253,7 +257,10 @@ mod module_tests {
         let d1 = Definition {
             span: Span::default(),
             name: "f".to_string(),
-            context: TypingContext { bindings: vec![] },
+            context: TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             body: Term::Lit(Lit::mk(2)),
             ret_ty: Ty::mk_int(),
         };
@@ -261,7 +268,10 @@ mod module_tests {
         let d2 = Definition {
             span: Span::default(),
             name: "g".to_string(),
-            context: TypingContext { bindings: vec![] },
+            context: TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             body: Term::Lit(Lit::mk(4)),
             ret_ty: Ty::mk_int(),
         };

--- a/lang/fun/src/syntax/terms/case.rs
+++ b/lang/fun/src/syntax/terms/case.rs
@@ -89,9 +89,8 @@ impl Check for Case {
             }
             match symbol_table.ctors.get(&case.xtor) {
                 Some(ctor_ctx) => {
-                    case.context
-                        .no_dups(&case.span.to_miette(), case.xtor.clone())?;
-                    case.context.compare_to(&case.span.to_miette(), ctor_ctx)?;
+                    case.context.no_dups(case.xtor.clone())?;
+                    case.context.compare_to(ctor_ctx)?;
 
                     let mut new_context = context.clone();
                     new_context
@@ -151,12 +150,17 @@ mod test {
             "ListInt".to_owned(),
             (Polarity::Data, vec!["Nil".to_owned(), "Cons".to_owned()]),
         );
-        symbol_table
-            .ctors
-            .insert("Nil".to_owned(), TypingContext { bindings: vec![] });
+        symbol_table.ctors.insert(
+            "Nil".to_owned(),
+            TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
+        );
         symbol_table.ctors.insert(
             "Cons".to_owned(),
             TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -175,13 +179,17 @@ mod test {
                 Clause {
                     span: Span::default(),
                     xtor: "Nil".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     rhs: Lit::mk(1).into(),
                 },
                 Clause {
                     span: Span::default(),
                     xtor: "Cons".to_owned(),
                     context: TypingContext {
+                        span: Span::default(),
                         bindings: vec![
                             ContextBinding::TypedVar {
                                 var: "x".to_owned(),
@@ -202,6 +210,7 @@ mod test {
         .check(
             &symbol_table,
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedVar {
                     var: "x".to_owned(),
                     ty: Ty::mk_decl("ListInt"),
@@ -216,13 +225,17 @@ mod test {
                 Clause {
                     span: Span::default(),
                     xtor: "Nil".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     rhs: Lit::mk(1).into(),
                 },
                 Clause {
                     span: Span::default(),
                     xtor: "Cons".to_owned(),
                     context: TypingContext {
+                        span: Span::default(),
                         bindings: vec![
                             ContextBinding::TypedVar {
                                 var: "x".to_owned(),
@@ -264,6 +277,7 @@ mod test {
         symbol_table.ctors.insert(
             "Tup".to_owned(),
             TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -282,6 +296,7 @@ mod test {
                 span: Span::default(),
                 xtor: "Tup".to_owned(),
                 context: TypingContext {
+                    span: Span::default(),
                     bindings: vec![
                         ContextBinding::TypedVar {
                             var: "x".to_owned(),
@@ -301,6 +316,7 @@ mod test {
         .check(
             &symbol_table,
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedVar {
                     var: "x".to_owned(),
                     ty: Ty::mk_decl("TupIntInt"),
@@ -315,6 +331,7 @@ mod test {
                 span: Span::default(),
                 xtor: "Tup".to_owned(),
                 context: TypingContext {
+                    span: Span::default(),
                     bindings: vec![
                         ContextBinding::TypedVar {
                             var: "x".to_owned(),
@@ -352,12 +369,17 @@ mod test {
             "ListInt".to_owned(),
             (Polarity::Data, vec!["Nil".to_owned(), "Cons".to_owned()]),
         );
-        symbol_table
-            .ctors
-            .insert("Nil".to_owned(), TypingContext { bindings: vec![] });
+        symbol_table.ctors.insert(
+            "Nil".to_owned(),
+            TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
+        );
         symbol_table.ctors.insert(
             "Cons".to_owned(),
             TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -376,6 +398,7 @@ mod test {
                 span: Span::default(),
                 xtor: "Tup".to_owned(),
                 context: TypingContext {
+                    span: Span::default(),
                     bindings: vec![
                         ContextBinding::TypedVar {
                             var: "x".to_owned(),
@@ -394,7 +417,10 @@ mod test {
         }
         .check(
             &symbol_table,
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_int(),
         );
         assert!(result.is_err())
@@ -417,6 +443,7 @@ mod test {
                 span: Span::default(),
                 xtor: "Tup".to_owned(),
                 context: TypingContext {
+                    span: Span::default(),
                     bindings: vec![
                         ContextBinding::TypedVar {
                             var: "x".to_string(),

--- a/lang/fun/src/syntax/terms/cocase.rs
+++ b/lang/fun/src/syntax/terms/cocase.rs
@@ -104,12 +104,8 @@ impl Check for Cocase {
                 }
                 Some(info) => info,
             };
-            cocase
-                .context
-                .no_dups(&cocase.span.to_miette(), cocase.xtor.clone())?;
-            cocase
-                .context
-                .compare_to(&cocase.span.to_miette(), dtor_ctx)?;
+            cocase.context.no_dups(cocase.xtor.clone())?;
+            cocase.context.compare_to(dtor_ctx)?;
 
             let mut new_context = context.clone();
             new_context
@@ -162,11 +158,23 @@ mod test {
         );
         symbol_table.dtors.insert(
             "Fst".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_int()),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_int(),
+            ),
         );
         symbol_table.dtors.insert(
             "Snd".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_int()),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_int(),
+            ),
         );
         let result = Cocase {
             span: Span::default(),
@@ -174,13 +182,19 @@ mod test {
                 Clause {
                     span: Span::default(),
                     xtor: "Fst".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     rhs: Lit::mk(1).into(),
                 },
                 Clause {
                     span: Span::default(),
                     xtor: "Snd".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     rhs: Lit::mk(2).into(),
                 },
             ],
@@ -188,7 +202,10 @@ mod test {
         }
         .check(
             &symbol_table,
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_decl("LPairIntInt"),
         )
         .unwrap();
@@ -198,13 +215,19 @@ mod test {
                 Clause {
                     span: Span::default(),
                     xtor: "Fst".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     rhs: Lit::mk(1).into(),
                 },
                 Clause {
                     span: Span::default(),
                     xtor: "Snd".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     rhs: Lit::mk(2).into(),
                 },
             ],
@@ -223,6 +246,7 @@ mod test {
             "Ap".to_owned(),
             (
                 TypingContext {
+                    span: Span::default(),
                     bindings: vec![ContextBinding::TypedVar {
                         var: "x".to_owned(),
                         ty: Ty::mk_int(),
@@ -237,6 +261,7 @@ mod test {
                 span: Span::default(),
                 xtor: "Ap".to_owned(),
                 context: TypingContext {
+                    span: Span::default(),
                     bindings: vec![ContextBinding::TypedVar {
                         var: "x".to_owned(),
                         ty: Ty::mk_int(),
@@ -248,7 +273,10 @@ mod test {
         }
         .check(
             &symbol_table,
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_decl("FunIntInt"),
         )
         .unwrap();
@@ -258,6 +286,7 @@ mod test {
                 span: Span::default(),
                 xtor: "Ap".to_owned(),
                 context: TypingContext {
+                    span: Span::default(),
                     bindings: vec![ContextBinding::TypedVar {
                         var: "x".to_owned(),
                         ty: Ty::mk_int(),
@@ -285,6 +314,7 @@ mod test {
             "Ap".to_owned(),
             (
                 TypingContext {
+                    span: Span::default(),
                     bindings: vec![ContextBinding::TypedVar {
                         var: "x".to_owned(),
                         ty: Ty::mk_int(),
@@ -298,14 +328,20 @@ mod test {
             cocases: vec![Clause {
                 span: Span::default(),
                 xtor: "Ap".to_owned(),
-                context: TypingContext { bindings: vec![] },
+                context: TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 rhs: Lit::mk(1).into(),
             }],
             ty: None,
         }
         .check(
             &symbol_table,
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_decl("ListInt"),
         );
         assert!(result.is_err())
@@ -326,13 +362,19 @@ mod test {
                 Clause {
                     span: Span::default(),
                     xtor: "Hd".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     rhs: Term::Lit(Lit::mk(2)),
                 },
                 Clause {
                     span: Span::default(),
                     xtor: "Tl".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     rhs: Term::Lit(Lit::mk(4)),
                 },
             ],

--- a/lang/fun/src/syntax/terms/constructor.rs
+++ b/lang/fun/src/syntax/terms/constructor.rs
@@ -113,12 +113,17 @@ mod test {
             "ListInt".to_owned(),
             (Polarity::Data, vec!["Nil".to_owned(), "Cons".to_owned()]),
         );
-        symbol_table
-            .ctors
-            .insert("Nil".to_owned(), TypingContext { bindings: vec![] });
+        symbol_table.ctors.insert(
+            "Nil".to_owned(),
+            TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
+        );
         symbol_table.ctors.insert(
             "Cons".to_owned(),
             TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -143,7 +148,10 @@ mod test {
         }
         .check(
             &mut example_symbols(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_decl("ListInt"),
         )
         .unwrap();
@@ -177,6 +185,7 @@ mod test {
         .check(
             &mut example_symbols(),
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedVar {
                     var: "x".to_owned(),
                     ty: Ty::mk_int(),
@@ -240,7 +249,10 @@ mod test {
         }
         .check(
             &example_symbols(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_decl("ListInt"),
         );
         assert!(result.is_err());

--- a/lang/fun/src/syntax/terms/destructor.rs
+++ b/lang/fun/src/syntax/terms/destructor.rs
@@ -126,11 +126,23 @@ mod destructor_tests {
         );
         symbol_table.dtors.insert(
             "Fst".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_int()),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_int(),
+            ),
         );
         symbol_table.dtors.insert(
             "Snd".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_int()),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_int(),
+            ),
         );
         let result = Destructor {
             span: Span::default(),
@@ -142,6 +154,7 @@ mod destructor_tests {
         .check(
             &symbol_table,
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedVar {
                     var: "x".to_owned(),
                     ty: Ty::mk_decl("LPairIntInt"),
@@ -177,6 +190,7 @@ mod destructor_tests {
             "Ap".to_owned(),
             (
                 TypingContext {
+                    span: Span::default(),
                     bindings: vec![
                         ContextBinding::TypedVar {
                             var: "x".to_owned(),
@@ -207,6 +221,7 @@ mod destructor_tests {
         .check(
             &symbol_table,
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -255,6 +270,7 @@ mod destructor_tests {
         .check(
             &SymbolTable::default(),
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedVar {
                     var: "x".to_owned(),
                     ty: Ty::mk_decl("StreamInt"),

--- a/lang/fun/src/syntax/terms/fun.rs
+++ b/lang/fun/src/syntax/terms/fun.rs
@@ -107,6 +107,7 @@ mod test {
             "main".to_owned(),
             (
                 TypingContext {
+                    span: Span::default(),
                     bindings: vec![
                         ContextBinding::TypedVar {
                             var: "x".to_owned(),
@@ -132,7 +133,10 @@ mod test {
         }
         .check(
             &symbol_table,
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_int(),
         )
         .unwrap();
@@ -157,7 +161,10 @@ mod test {
         }
         .check(
             &SymbolTable::default(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_int(),
         );
         assert!(result.is_err())

--- a/lang/fun/src/syntax/terms/goto.rs
+++ b/lang/fun/src/syntax/terms/goto.rs
@@ -9,7 +9,6 @@ use printer::{
 };
 
 use crate::{
-    parser::util::ToMiette,
     syntax::{
         context::TypingContext,
         types::{OptTyped, Ty},
@@ -70,7 +69,7 @@ impl Check for Goto {
         context: &TypingContext,
         expected: &Ty,
     ) -> Result<Self, Error> {
-        let cont_type = context.lookup_covar(&self.span.to_miette(), &self.target)?;
+        let cont_type = context.lookup_covar(&self.target)?;
         let term_checked = self.term.check(symbol_table, context, &cont_type)?;
         Ok(Goto {
             term: term_checked,
@@ -109,6 +108,7 @@ mod test {
         .check(
             &SymbolTable::default(),
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedCovar {
                     covar: "a".to_owned(),
                     ty: Ty::mk_int(),
@@ -135,7 +135,10 @@ mod test {
         }
         .check(
             &SymbolTable::default(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_int(),
         );
         assert!(result.is_err())

--- a/lang/fun/src/syntax/terms/ifc.rs
+++ b/lang/fun/src/syntax/terms/ifc.rs
@@ -129,7 +129,10 @@ mod test {
         }
         .check(
             &SymbolTable::default(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_int(),
         )
         .unwrap();
@@ -158,6 +161,7 @@ mod test {
         .check(
             &SymbolTable::default(),
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedVar {
                     var: "x".to_owned(),
                     ty: Ty::mk_decl("ListInt"),

--- a/lang/fun/src/syntax/terms/ifz.rs
+++ b/lang/fun/src/syntax/terms/ifz.rs
@@ -109,7 +109,10 @@ mod test {
         }
         .check(
             &SymbolTable::default(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_int(),
         )
         .unwrap();
@@ -134,6 +137,7 @@ mod test {
         .check(
             &SymbolTable::default(),
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedVar {
                     var: "x".to_owned(),
                     ty: Ty::mk_decl("ListInt"),

--- a/lang/fun/src/syntax/terms/label.rs
+++ b/lang/fun/src/syntax/terms/label.rs
@@ -106,7 +106,10 @@ mod test {
         }
         .check(
             &SymbolTable::default(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_int(),
         )
         .unwrap();
@@ -129,6 +132,7 @@ mod test {
         .check(
             &SymbolTable::default(),
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedVar {
                     var: "x".to_owned(),
                     ty: Ty::mk_decl("ListInt"),

--- a/lang/fun/src/syntax/terms/lit.rs
+++ b/lang/fun/src/syntax/terms/lit.rs
@@ -74,13 +74,17 @@ mod test {
         syntax::{context::TypingContext, terms::Lit, types::Ty},
         typing::symbol_table::SymbolTable,
     };
+    use codespan::Span;
 
     #[test]
     fn check_lit() {
         let result = Lit::mk(1)
             .check(
                 &SymbolTable::default(),
-                &TypingContext { bindings: vec![] },
+                &TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &Ty::mk_int(),
             )
             .unwrap();
@@ -92,7 +96,10 @@ mod test {
     fn check_lit_fail() {
         let result = Lit::mk(1).check(
             &SymbolTable::default(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_decl("ListInt"),
         );
         assert!(result.is_err())

--- a/lang/fun/src/syntax/terms/local_let.rs
+++ b/lang/fun/src/syntax/terms/local_let.rs
@@ -123,7 +123,10 @@ mod test {
         }
         .check(
             &SymbolTable::default(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_int(),
         )
         .unwrap();
@@ -151,12 +154,17 @@ mod test {
             "ListInt".to_owned(),
             (Polarity::Data, vec!["Nil".to_owned(), "Cons".to_owned()]),
         );
-        symbol_table
-            .ctors
-            .insert("Nil".to_owned(), TypingContext { bindings: vec![] });
+        symbol_table.ctors.insert(
+            "Nil".to_owned(),
+            TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
+        );
         symbol_table.ctors.insert(
             "Cons".to_owned(),
             TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -187,7 +195,10 @@ mod test {
         }
         .check(
             &symbol_table,
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_decl("ListInt"),
         );
         assert!(result.is_err())

--- a/lang/fun/src/syntax/terms/op.rs
+++ b/lang/fun/src/syntax/terms/op.rs
@@ -128,7 +128,10 @@ mod test {
         }
         .check(
             &SymbolTable::default(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_int(),
         )
         .unwrap();
@@ -151,7 +154,10 @@ mod test {
         }
         .check(
             &SymbolTable::default(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             &Ty::mk_decl("ListInt"),
         );
         assert!(result.is_err())

--- a/lang/fun/src/syntax/terms/paren.rs
+++ b/lang/fun/src/syntax/terms/paren.rs
@@ -78,13 +78,17 @@ mod test {
         },
         typing::symbol_table::SymbolTable,
     };
+    use codespan::Span;
 
     #[test]
     fn check_parens() {
         let result = Paren::mk(Lit::mk(1))
             .check(
                 &SymbolTable::default(),
-                &TypingContext { bindings: vec![] },
+                &TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &Ty::mk_int(),
             )
             .unwrap();

--- a/lang/fun/src/syntax/terms/var.rs
+++ b/lang/fun/src/syntax/terms/var.rs
@@ -65,7 +65,7 @@ impl Check for Var {
         context: &TypingContext,
         expected: &Ty,
     ) -> Result<Self, Error> {
-        let found_ty = context.lookup_var(&self.span.to_miette(), &self.var)?;
+        let found_ty = context.lookup_var(&self.var)?;
         check_equality(&self.span.to_miette(), expected, &found_ty)?;
         Ok(Var {
             ty: Some(expected.clone()),
@@ -93,6 +93,7 @@ mod test {
             .check(
                 &SymbolTable::default(),
                 &TypingContext {
+                    span: Span::default(),
                     bindings: vec![ContextBinding::TypedVar {
                         var: "x".to_owned(),
                         ty: Ty::mk_int(),
@@ -113,6 +114,7 @@ mod test {
         let result = Var::mk("x").check(
             &SymbolTable::default(),
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedVar {
                     var: "x".to_owned(),
                     ty: Ty::mk_int(),

--- a/lang/fun/src/typing/check.rs
+++ b/lang/fun/src/typing/check.rs
@@ -60,7 +60,7 @@ pub fn check_args(
                 },
                 ContextBinding::TypedCovar { ty, .. },
             ) => {
-                let found_ty = context.lookup_covar(span, &cov)?;
+                let found_ty = context.lookup_covar(&cov)?;
                 if Some(&found_ty) == subst_ty.as_ref() || subst_ty.is_none() {
                     Ok(())
                 } else {
@@ -128,12 +128,16 @@ mod check_tests {
                         CtorSig {
                             span: Span::default(),
                             name: "Nil".to_owned(),
-                            args: TypingContext { bindings: vec![] },
+                            args: TypingContext {
+                                span: Span::default(),
+                                bindings: vec![],
+                            },
                         },
                         CtorSig {
                             span: Span::default(),
                             name: "Cons".to_owned(),
                             args: TypingContext {
+                                span: Span::default(),
                                 bindings: vec![
                                     ContextBinding::TypedVar {
                                         var: "x".to_owned(),
@@ -156,13 +160,19 @@ mod check_tests {
                         DtorSig {
                             span: Span::default(),
                             name: "Hd".to_owned(),
-                            args: TypingContext { bindings: vec![] },
+                            args: TypingContext {
+                                span: Span::default(),
+                                bindings: vec![],
+                            },
                             cont_ty: Ty::mk_int(),
                         },
                         DtorSig {
                             span: Span::default(),
                             name: "Tl".to_owned(),
-                            args: TypingContext { bindings: vec![] },
+                            args: TypingContext {
+                                span: Span::default(),
+                                bindings: vec![],
+                            },
                             cont_ty: Ty::mk_decl("StreamInt"),
                         },
                     ],
@@ -171,7 +181,10 @@ mod check_tests {
                 Definition {
                     span: Span::default(),
                     name: "main".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     ret_ty: Ty::mk_decl("ListInt"),
                     body: Constructor {
                         span: Span::default(),
@@ -213,12 +226,16 @@ mod check_tests {
                         CtorSig {
                             span: Span::default(),
                             name: "Nil".to_owned(),
-                            args: TypingContext { bindings: vec![] },
+                            args: TypingContext {
+                                span: Span::default(),
+                                bindings: vec![],
+                            },
                         },
                         CtorSig {
                             span: Span::default(),
                             name: "Cons".to_owned(),
                             args: TypingContext {
+                                span: Span::default(),
                                 bindings: vec![
                                     ContextBinding::TypedVar {
                                         var: "x".to_owned(),
@@ -241,13 +258,19 @@ mod check_tests {
                         DtorSig {
                             span: Span::default(),
                             name: "Hd".to_owned(),
-                            args: TypingContext { bindings: vec![] },
+                            args: TypingContext {
+                                span: Span::default(),
+                                bindings: vec![],
+                            },
                             cont_ty: Ty::mk_int(),
                         },
                         DtorSig {
                             span: Span::default(),
                             name: "Tl".to_owned(),
-                            args: TypingContext { bindings: vec![] },
+                            args: TypingContext {
+                                span: Span::default(),
+                                bindings: vec![],
+                            },
                             cont_ty: Ty::mk_decl("StreamInt"),
                         },
                     ],
@@ -256,7 +279,10 @@ mod check_tests {
                 Definition {
                     span: Span::default(),
                     name: "main".to_owned(),
-                    context: TypingContext { bindings: vec![] },
+                    context: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     ret_ty: Ty::mk_decl("ListInt"),
                     body: Constructor {
                         span: Span::default(),
@@ -331,12 +357,17 @@ mod check_tests {
             "ListInt".to_owned(),
             (Polarity::Data, vec!["Nil".to_owned(), "Cons".to_owned()]),
         );
-        symbol_table
-            .ctors
-            .insert("Nil".to_owned(), TypingContext { bindings: vec![] });
+        symbol_table.ctors.insert(
+            "Nil".to_owned(),
+            TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
+        );
         symbol_table.ctors.insert(
             "Cons".to_owned(),
             TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -352,7 +383,10 @@ mod check_tests {
         let result = check_args(
             &Span::default().to_miette(),
             &symbol_table,
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             vec![
                 SubstitutionBinding::TermBinding(
                     Lit {
@@ -372,6 +406,7 @@ mod check_tests {
                 ),
             ],
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -411,6 +446,7 @@ mod check_tests {
             &Span::default().to_miette(),
             &SymbolTable::default(),
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedCovar {
                         covar: "c".to_owned(),
@@ -433,6 +469,7 @@ mod check_tests {
                 },
             ],
             &TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedCovar {
                         covar: "a".to_owned(),
@@ -463,7 +500,10 @@ mod check_tests {
         let result = check_args(
             &Span::default().to_miette(),
             &SymbolTable::default(),
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             vec![SubstitutionBinding::TermBinding(
                 Lit {
                     span: Span::default(),
@@ -471,7 +511,10 @@ mod check_tests {
                 }
                 .into(),
             )],
-            &TypingContext { bindings: vec![] },
+            &TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
         );
         assert!(result.is_err())
     }

--- a/lang/fun/src/typing/symbol_table.rs
+++ b/lang/fun/src/typing/symbol_table.rs
@@ -210,6 +210,7 @@ mod symbol_table_tests {
         },
     };
     use codespan::Span;
+
     fn example_data() -> DataDeclaration {
         DataDeclaration {
             span: Span::default(),
@@ -218,12 +219,16 @@ mod symbol_table_tests {
                 CtorSig {
                     span: Span::default(),
                     name: "Nil".to_owned(),
-                    args: TypingContext { bindings: vec![] },
+                    args: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                 },
                 CtorSig {
                     span: Span::default(),
                     name: "Cons".to_owned(),
                     args: TypingContext {
+                        span: Span::default(),
                         bindings: vec![
                             ContextBinding::TypedVar {
                                 var: "x".to_owned(),
@@ -247,13 +252,19 @@ mod symbol_table_tests {
                 DtorSig {
                     span: Span::default(),
                     name: "Hd".to_owned(),
-                    args: TypingContext { bindings: vec![] },
+                    args: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     cont_ty: Ty::mk_int(),
                 },
                 DtorSig {
                     span: Span::default(),
                     name: "Tl".to_owned(),
-                    args: TypingContext { bindings: vec![] },
+                    args: TypingContext {
+                        span: Span::default(),
+                        bindings: vec![],
+                    },
                     cont_ty: Ty::mk_decl("StreamInt"),
                 },
             ],
@@ -263,7 +274,10 @@ mod symbol_table_tests {
         Definition {
             span: Span::default(),
             name: "main".to_owned(),
-            context: TypingContext { bindings: vec![] },
+            context: TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
             ret_ty: Ty::mk_decl("ListInt"),
             body: Constructor {
                 span: Span::default(),
@@ -312,12 +326,17 @@ mod symbol_table_tests {
             "StreamInt".to_owned(),
             (Polarity::Codata, vec!["Hd".to_owned(), "Tl".to_owned()]),
         );
-        expected
-            .ctors
-            .insert("Nil".to_owned(), TypingContext { bindings: vec![] });
+        expected.ctors.insert(
+            "Nil".to_owned(),
+            TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
+        );
         expected.ctors.insert(
             "Cons".to_owned(),
             TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -332,15 +351,33 @@ mod symbol_table_tests {
         );
         expected.dtors.insert(
             "Hd".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_int()),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_int(),
+            ),
         );
         expected.dtors.insert(
             "Tl".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_decl("StreamInt")),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_decl("StreamInt"),
+            ),
         );
         expected.funs.insert(
             "main".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_decl("ListInt")),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_decl("ListInt"),
+            ),
         );
         assert_eq!(symbol_table, expected)
     }
@@ -353,12 +390,17 @@ mod symbol_table_tests {
             "ListInt".to_owned(),
             (Polarity::Data, vec!["Nil".to_owned(), "Cons".to_owned()]),
         );
-        expected
-            .ctors
-            .insert("Nil".to_owned(), TypingContext { bindings: vec![] });
+        expected.ctors.insert(
+            "Nil".to_owned(),
+            TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
+        );
         expected.ctors.insert(
             "Cons".to_owned(),
             TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -384,11 +426,23 @@ mod symbol_table_tests {
         );
         expected.dtors.insert(
             "Hd".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_int()),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_int(),
+            ),
         );
         expected.dtors.insert(
             "Tl".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_decl("StreamInt")),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_decl("StreamInt"),
+            ),
         );
         assert_eq!(symbol_table, expected)
     }
@@ -399,7 +453,13 @@ mod symbol_table_tests {
         let mut expected = SymbolTable::default();
         expected.funs.insert(
             "main".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_decl("ListInt")),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_decl("ListInt"),
+            ),
         );
         assert_eq!(symbol_table, expected)
     }

--- a/lang/fun2core/src/lib.rs
+++ b/lang/fun2core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod terms;
 
 #[cfg(test)]
 pub mod symbol_tables {
+    use codespan::Span;
     use fun::{
         syntax::{
             context::{ContextBinding, TypingContext},
@@ -15,10 +16,17 @@ pub mod symbol_tables {
 
     fn ctors_list() -> HashMap<String, TypingContext> {
         let mut ctors = HashMap::new();
-        ctors.insert("Nil".to_owned(), TypingContext { bindings: vec![] });
+        ctors.insert(
+            "Nil".to_owned(),
+            TypingContext {
+                span: Span::default(),
+                bindings: vec![],
+            },
+        );
         ctors.insert(
             "Cons".to_owned(),
             TypingContext {
+                span: Span::default(),
                 bindings: vec![
                     ContextBinding::TypedVar {
                         var: "x".to_owned(),
@@ -38,11 +46,23 @@ pub mod symbol_tables {
         let mut dtors = HashMap::new();
         dtors.insert(
             "Fst".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_int()),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_int(),
+            ),
         );
         dtors.insert(
             "Snd".to_owned(),
-            (TypingContext { bindings: vec![] }, Ty::mk_int()),
+            (
+                TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
+                Ty::mk_int(),
+            ),
         );
         dtors
     }

--- a/lang/fun2core/src/program.rs
+++ b/lang/fun2core/src/program.rs
@@ -234,6 +234,7 @@ mod compile_tests {
             span: Span::default(),
             name: "main".to_owned(),
             context: fun::syntax::context::TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedCovar {
                     covar: "a".to_owned(),
                     ty: Ty::mk_int(),
@@ -248,6 +249,7 @@ mod compile_tests {
             span: Span::default(),
             name: "id".to_owned(),
             context: fun::syntax::context::TypingContext {
+                span: Span::default(),
                 bindings: vec![ContextBinding::TypedVar {
                     var: "x".to_owned(),
                     ty: Ty::mk_int(),

--- a/lang/fun2core/src/terms/case.rs
+++ b/lang/fun2core/src/terms/case.rs
@@ -52,6 +52,7 @@ fn compile_clause(
 #[cfg(test)]
 mod compile_tests {
     use crate::{definition::CompileWithCont, symbol_tables::table_list};
+    use codespan::Span;
     use core::syntax::{
         context::Context,
         term::{Cns, Prd},
@@ -65,7 +66,10 @@ mod compile_tests {
         let term_typed = term
             .check(
                 &table_list(),
-                &TypingContext { bindings: vec![] },
+                &TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &fun::syntax::types::Ty::mk_int(),
             )
             .unwrap();

--- a/lang/fun2core/src/terms/cocase.rs
+++ b/lang/fun2core/src/terms/cocase.rs
@@ -86,6 +86,7 @@ fn compile_clause(
 
 #[cfg(test)]
 mod compile_tests {
+    use codespan::Span;
     use fun::{parse_term, syntax::context::TypingContext, typing::check::Check};
 
     use crate::{definition::CompileWithCont, symbol_tables::table_lpair};
@@ -101,7 +102,10 @@ mod compile_tests {
         let term_typed = term
             .check(
                 &table_lpair(),
-                &TypingContext { bindings: vec![] },
+                &TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &fun::syntax::types::Ty::mk_decl("LPairIntInt"),
             )
             .unwrap();

--- a/lang/fun2core/src/terms/constructor.rs
+++ b/lang/fun2core/src/terms/constructor.rs
@@ -50,6 +50,7 @@ impl CompileWithCont for fun::syntax::terms::Constructor {
 
 #[cfg(test)]
 mod compile_tests {
+    use codespan::Span;
     use fun::{parse_term, syntax::context::TypingContext, typing::check::Check};
 
     use crate::{definition::CompileWithCont, symbol_tables::table_list};
@@ -61,7 +62,10 @@ mod compile_tests {
         let term_typed = term
             .check(
                 &table_list(),
-                &TypingContext { bindings: vec![] },
+                &TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &fun::syntax::types::Ty::mk_decl("ListInt"),
             )
             .unwrap();

--- a/lang/fun2core/src/terms/destructor.rs
+++ b/lang/fun2core/src/terms/destructor.rs
@@ -37,6 +37,7 @@ impl CompileWithCont for fun::syntax::terms::Destructor {
 
 #[cfg(test)]
 mod compile_tests {
+    use codespan::Span;
     use fun::{parse_term, typing::check::Check};
 
     use crate::{definition::CompileWithCont, symbol_tables::table_lpair};
@@ -53,7 +54,10 @@ mod compile_tests {
         let term_typed = term
             .check(
                 &table_lpair(),
-                &fun::syntax::context::TypingContext { bindings: vec![] },
+                &fun::syntax::context::TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &fun::syntax::types::Ty::mk_int(),
             )
             .unwrap();
@@ -159,7 +163,10 @@ mod compile_tests {
         let term_typed = term
             .check(
                 &table_lpair(),
-                &fun::syntax::context::TypingContext { bindings: vec![] },
+                &fun::syntax::context::TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &fun::syntax::types::Ty::mk_int(),
             )
             .unwrap();

--- a/lang/fun2core/src/terms/fun_call.rs
+++ b/lang/fun2core/src/terms/fun_call.rs
@@ -61,6 +61,7 @@ impl CompileWithCont for fun::syntax::terms::Fun {
 
 #[cfg(test)]
 mod compile_tests {
+    use codespan::Span;
     use fun::{
         parse_term,
         syntax::context::{ContextBinding, TypingContext},
@@ -82,6 +83,7 @@ mod compile_tests {
                         "fac".to_owned(),
                         (
                             TypingContext {
+                                span: Span::default(),
                                 bindings: vec![ContextBinding::TypedVar {
                                     var: "x".to_owned(),
                                     ty: fun::syntax::types::Ty::mk_int(),
@@ -98,7 +100,10 @@ mod compile_tests {
                         ty_ctors: HashMap::new(),
                     }
                 },
-                &fun::syntax::context::TypingContext { bindings: vec![] },
+                &fun::syntax::context::TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &fun::syntax::types::Ty::mk_int(),
             )
             .unwrap();

--- a/lang/fun2core/src/terms/goto.rs
+++ b/lang/fun2core/src/terms/goto.rs
@@ -29,7 +29,7 @@ impl CompileWithCont for fun::syntax::terms::Goto {
 
 #[cfg(test)]
 mod compile_tests {
-
+    use codespan::Span;
     use fun::{parse_term, typing::check::Check};
 
     use crate::definition::CompileWithCont;
@@ -43,6 +43,7 @@ mod compile_tests {
             .check(
                 &Default::default(),
                 &fun::syntax::context::TypingContext {
+                    span: Span::default(),
                     bindings: vec![fun::syntax::context::ContextBinding::TypedCovar {
                         covar: "a".to_owned(),
                         ty: fun::syntax::types::Ty::mk_int(),
@@ -84,6 +85,7 @@ mod compile_tests {
             .check(
                 &Default::default(),
                 &fun::syntax::context::TypingContext {
+                    span: Span::default(),
                     bindings: vec![fun::syntax::context::ContextBinding::TypedVar {
                         var: "x".to_owned(),
                         ty: fun::syntax::types::Ty::mk_int(),

--- a/lang/fun2core/src/terms/ifc.rs
+++ b/lang/fun2core/src/terms/ifc.rs
@@ -27,9 +27,9 @@ impl CompileWithCont for fun::syntax::terms::IfC {
 
 #[cfg(test)]
 mod compile_tests {
-
     use std::rc::Rc;
 
+    use codespan::Span;
     use fun::{parse_term, typing::check::Check};
 
     use crate::definition::CompileWithCont;
@@ -93,6 +93,7 @@ mod compile_tests {
             .check(
                 &Default::default(),
                 &fun::syntax::context::TypingContext {
+                    span: Span::default(),
                     bindings: vec![fun::syntax::context::ContextBinding::TypedVar {
                         var: "x".to_owned(),
                         ty: fun::syntax::types::Ty::mk_int(),

--- a/lang/fun2core/src/terms/ifz.rs
+++ b/lang/fun2core/src/terms/ifz.rs
@@ -22,9 +22,9 @@ impl CompileWithCont for fun::syntax::terms::IfZ {
 
 #[cfg(test)]
 mod compile_tests {
-
     use std::rc::Rc;
 
+    use codespan::Span;
     use fun::{parse_term, typing::check::Check};
 
     use crate::definition::CompileWithCont;
@@ -86,6 +86,7 @@ mod compile_tests {
             .check(
                 &Default::default(),
                 &fun::syntax::context::TypingContext {
+                    span: Span::default(),
                     bindings: vec![fun::syntax::context::ContextBinding::TypedVar {
                         var: "x".to_owned(),
                         ty: fun::syntax::types::Ty::mk_int(),

--- a/lang/fun2core/src/terms/label.rs
+++ b/lang/fun2core/src/terms/label.rs
@@ -56,7 +56,7 @@ impl CompileWithCont for fun::syntax::terms::Label {
 
 #[cfg(test)]
 mod compile_tests {
-
+    use codespan::Span;
     use fun::{parse_term, typing::check::Check};
 
     use crate::definition::CompileWithCont;
@@ -69,7 +69,10 @@ mod compile_tests {
         let term_typed = term
             .check(
                 &Default::default(),
-                &fun::syntax::context::TypingContext { bindings: vec![] },
+                &fun::syntax::context::TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &fun::syntax::types::Ty::mk_int(),
             )
             .unwrap();
@@ -105,7 +108,10 @@ mod compile_tests {
         let term_typed = term
             .check(
                 &Default::default(),
-                &fun::syntax::context::TypingContext { bindings: vec![] },
+                &fun::syntax::context::TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &fun::syntax::types::Ty::mk_int(),
             )
             .unwrap();

--- a/lang/fun2core/src/terms/let_exp.rs
+++ b/lang/fun2core/src/terms/let_exp.rs
@@ -42,6 +42,7 @@ impl CompileWithCont for fun::syntax::terms::Let {
 
 #[cfg(test)]
 mod compile_tests {
+    use codespan::Span;
     use fun::{parse_term, typing::check::Check};
 
     use crate::{definition::CompileWithCont, symbol_tables::table_list};
@@ -54,7 +55,10 @@ mod compile_tests {
         let term_typed = term
             .check(
                 &Default::default(),
-                &fun::syntax::context::TypingContext { bindings: vec![] },
+                &fun::syntax::context::TypingContext {
+                    span: Span::default(),
+                    bindings: vec![],
+                },
                 &fun::syntax::types::Ty::mk_int(),
             )
             .unwrap();
@@ -121,6 +125,7 @@ mod compile_tests {
             .check(
                 &table_list(),
                 &fun::syntax::context::TypingContext {
+                    span: Span::default(),
                     bindings: vec![fun::syntax::context::ContextBinding::TypedVar {
                         var: "x".to_owned(),
                         ty: fun::syntax::types::Ty::mk_int(),

--- a/lang/fun2core/src/terms/op.rs
+++ b/lang/fun2core/src/terms/op.rs
@@ -23,6 +23,7 @@ impl CompileWithCont for fun::syntax::terms::Op {
 
 #[cfg(test)]
 mod compile_tests {
+    use codespan::Span;
     use fun::{parse_term, typing::check::Check};
 
     use crate::definition::CompileWithCont;
@@ -68,6 +69,7 @@ mod compile_tests {
             .check(
                 &Default::default(),
                 &fun::syntax::context::TypingContext {
+                    span: Span::default(),
                     bindings: vec![fun::syntax::context::ContextBinding::TypedVar {
                         var: "x".to_owned(),
                         ty: fun::syntax::types::Ty::mk_int(),


### PR DESCRIPTION
Since `TypingContext`s are a struct now, we can add codespans for them in `Fun`. Most of the changes are only to make the tests correct.