### PR TITLE
Reenable codespans in miette reports

### DIFF
--- a/lang/driver/src/result.rs
+++ b/lang/driver/src/result.rs
@@ -1,20 +1,13 @@
-use std::fmt::Display;
-
 use thiserror::Error;
 
 use miette::Diagnostic;
 
 #[derive(Error, Diagnostic, Debug, Clone)]
 pub enum DriverError {
-    ParseError(fun::parser::result::ParseError),
-    TypeError(fun::typing::errors::Error),
-}
-
-impl Display for DriverError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DriverError::ParseError(parse_error) => write!(f, "{parse_error}"),
-            DriverError::TypeError(error) => write!(f, "{error}"),
-        }
-    }
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ParseError(#[from] fun::parser::result::ParseError),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    TypeError(#[from] fun::typing::errors::Error),
 }


### PR DESCRIPTION
The introduction of this intermediate `DriverError` datastructure was why we lost the nice error messages. We have to mark it as "transparent" for the `Error` and `Diagnostic` trait.