### PR TITLE
Use pretty_assertions crate for testing codegen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ derivative = { version = "2" }
 thiserror = { version = "1" }
 miette = { version = "5" }
 pretty = { version = "0.11", features = ["termcolor"] }
+pretty_assertions = { version = "1.4.1" }

--- a/lang/axcut2aarch64/Cargo.toml
+++ b/lang/axcut2aarch64/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 axcut = { path = "../axcut" }
 axcut2backend = { path = "../axcut2backend" }
 printer = { path = "../printer" }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/lang/axcut2aarch64/tests/arith.rs
+++ b/lang/axcut2aarch64/tests/arith.rs
@@ -5,6 +5,8 @@ use axcut2aarch64::Backend;
 use axcut2backend::code::pretty;
 use axcut2backend::coder::compile;
 
+use pretty_assertions::assert_eq;
+
 use std::collections::HashSet;
 use std::rc::Rc;
 

--- a/lang/axcut2aarch64/tests/closure.rs
+++ b/lang/axcut2aarch64/tests/closure.rs
@@ -8,6 +8,8 @@ use axcut2backend::coder::compile;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2aarch64/tests/either.rs
+++ b/lang/axcut2aarch64/tests/either.rs
@@ -8,6 +8,8 @@ use axcut2backend::coder::compile;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2aarch64/tests/list.rs
+++ b/lang/axcut2aarch64/tests/list.rs
@@ -8,6 +8,8 @@ use axcut2backend::coder::compile;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2aarch64/tests/midi.rs
+++ b/lang/axcut2aarch64/tests/midi.rs
@@ -8,6 +8,8 @@ use axcut2backend::coder::compile;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2aarch64/tests/mini.rs
+++ b/lang/axcut2aarch64/tests/mini.rs
@@ -8,6 +8,8 @@ use axcut2backend::coder::compile;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2aarch64/tests/nonLinear.rs
+++ b/lang/axcut2aarch64/tests/nonLinear.rs
@@ -8,6 +8,8 @@ use axcut2backend::coder::compile;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2aarch64/tests/quad.rs
+++ b/lang/axcut2aarch64/tests/quad.rs
@@ -8,6 +8,8 @@ use axcut2backend::coder::compile;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2rv64/Cargo.toml
+++ b/lang/axcut2rv64/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 axcut = { path = "../axcut" }
 axcut2backend = { path = "../axcut2backend" }
+
+[dev-dependencies]
+pretty_assertions = { workspace =  true }

--- a/lang/axcut2rv64/tests/arith.rs
+++ b/lang/axcut2rv64/tests/arith.rs
@@ -8,6 +8,8 @@ use axcut2rv64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2rv64/tests/closure.rs
+++ b/lang/axcut2rv64/tests/closure.rs
@@ -8,6 +8,8 @@ use axcut2rv64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2rv64/tests/either.rs
+++ b/lang/axcut2rv64/tests/either.rs
@@ -8,6 +8,8 @@ use axcut2rv64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2rv64/tests/list.rs
+++ b/lang/axcut2rv64/tests/list.rs
@@ -8,6 +8,8 @@ use axcut2rv64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2rv64/tests/midi.rs
+++ b/lang/axcut2rv64/tests/midi.rs
@@ -8,6 +8,8 @@ use axcut2rv64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2rv64/tests/mini.rs
+++ b/lang/axcut2rv64/tests/mini.rs
@@ -8,6 +8,8 @@ use axcut2rv64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2rv64/tests/nonLinear.rs
+++ b/lang/axcut2rv64/tests/nonLinear.rs
@@ -8,6 +8,8 @@ use axcut2rv64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2rv64/tests/quad.rs
+++ b/lang/axcut2rv64/tests/quad.rs
@@ -8,6 +8,8 @@ use axcut2rv64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2x86_64/Cargo.toml
+++ b/lang/axcut2x86_64/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 axcut = { path = "../axcut" }
 axcut2backend = { path = "../axcut2backend" }
 printer = { path = "../printer" }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/lang/axcut2x86_64/tests/arith.rs
+++ b/lang/axcut2x86_64/tests/arith.rs
@@ -8,6 +8,8 @@ use axcut2x86_64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2x86_64/tests/closure.rs
+++ b/lang/axcut2x86_64/tests/closure.rs
@@ -8,6 +8,8 @@ use axcut2x86_64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2x86_64/tests/either.rs
+++ b/lang/axcut2x86_64/tests/either.rs
@@ -8,6 +8,8 @@ use axcut2x86_64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2x86_64/tests/list.rs
+++ b/lang/axcut2x86_64/tests/list.rs
@@ -8,6 +8,8 @@ use axcut2x86_64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2x86_64/tests/midi.rs
+++ b/lang/axcut2x86_64/tests/midi.rs
@@ -8,6 +8,8 @@ use axcut2x86_64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2x86_64/tests/mini.rs
+++ b/lang/axcut2x86_64/tests/mini.rs
@@ -8,6 +8,8 @@ use axcut2x86_64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2x86_64/tests/nonLinear.rs
+++ b/lang/axcut2x86_64/tests/nonLinear.rs
@@ -8,6 +8,8 @@ use axcut2x86_64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 

--- a/lang/axcut2x86_64/tests/quad.rs
+++ b/lang/axcut2x86_64/tests/quad.rs
@@ -8,6 +8,8 @@ use axcut2x86_64::Backend;
 use std::collections::HashSet;
 use std::rc::Rc;
 
+use pretty_assertions::assert_eq;
+
 use std::fs::File;
 use std::io::prelude::*;
 


### PR DESCRIPTION
Gives nice colorcoded diffs for assertion failures. This is extremely helpful in #103 to check the diff in the generated assembly.