### PR TITLE
Add CLI option to generate shell completion scripts

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 [dependencies]
 # CLI
 clap = { version = "4", features = ["derive"] }
+clap_complete = { version = "4.5.38" }
 termsize = "0.1"
 # Workspace dependencies
 driver = { path = "../lang/driver" }

--- a/app/src/cli/gen_completions.rs
+++ b/app/src/cli/gen_completions.rs
@@ -1,0 +1,40 @@
+use std::{fs::File, io::BufWriter, path::PathBuf};
+
+use clap::CommandFactory;
+use clap_complete::{
+    generate,
+    shells::{Bash, Elvish, Fish, PowerShell, Zsh},
+};
+
+use super::Cli;
+
+#[allow(clippy::enum_variant_names)]
+#[derive(clap::ValueEnum, Clone)]
+pub enum Shell {
+    Bash,
+    Elvish,
+    Fish,
+    PowerShell,
+    Zsh,
+}
+
+#[derive(clap::Args)]
+pub struct Args {
+    /// Target shell
+    shell: Shell,
+    /// Where the completion script should be saved.
+    #[clap(value_parser, value_name = "PATH")]
+    filepath: PathBuf,
+}
+
+pub fn exec(cmd: Args) -> miette::Result<()> {
+    let mut file = BufWriter::new(File::create(cmd.filepath).expect("Failed to create file"));
+    match cmd.shell {
+        Shell::Bash => generate(Bash, &mut Cli::command(), "pol", &mut file),
+        Shell::Elvish => generate(Elvish, &mut Cli::command(), "pol", &mut file),
+        Shell::Fish => generate(Fish, &mut Cli::command(), "pol", &mut file),
+        Shell::PowerShell => generate(PowerShell, &mut Cli::command(), "pol", &mut file),
+        Shell::Zsh => generate(Zsh, &mut Cli::command(), "pol", &mut file),
+    }
+    Ok(())
+}

--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -6,6 +6,7 @@ mod codegen;
 mod compile;
 mod fmt;
 mod focus;
+mod gen_completions;
 mod linearize;
 mod shrink;
 mod texify;
@@ -23,6 +24,7 @@ pub fn exec() -> miette::Result<()> {
         Linearize(args) => linearize::exec(args),
         Shrink(args) => shrink::exec(args),
         Texify(args) => texify::exec(args),
+        GenerateCompletion(args) => gen_completions::exec(args),
     }
 }
 
@@ -53,4 +55,6 @@ enum Command {
     Shrink(shrink::Args),
     /// Convert source code file to latex
     Texify(texify::Args),
+    /// Generate completion scripts for various shells
+    GenerateCompletion(gen_completions::Args),
 }


### PR DESCRIPTION
I recently added this to polarity, and this is also useful here. Allows to generate completion scripts for various shells, but you have to add them manually to the correct directory.

Cp. https://github.com/polarity-lang/polarity/pull/396