### PR TITLE
Remove self parameters from methods in backend traits

### DIFF
--- a/lang/axcut2aarch64/src/code.rs
+++ b/lang/axcut2aarch64/src/code.rs
@@ -268,55 +268,38 @@ impl Print for Code {
 }
 
 impl Instructions<Code, Register, Immediate> for Backend {
-    fn comment(&self, msg: String) -> Code {
+    fn comment(msg: String) -> Code {
         Code::COMMENT(msg)
     }
 
-    fn label(&self, name: Name) -> Code {
+    fn label(name: Name) -> Code {
         Code::LAB(name)
     }
 
-    fn jump(&self, temporary: Register, instructions: &mut Vec<Code>) {
+    fn jump(temporary: Register, instructions: &mut Vec<Code>) {
         instructions.push(Code::BR(temporary));
     }
 
-    fn jump_label(&self, name: Name, instructions: &mut Vec<Code>) {
+    fn jump_label(name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::B(name));
     }
 
-    fn jump_label_if_equal(
-        &self,
-        fst: Register,
-        snd: Register,
-        name: Name,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn jump_label_if_equal(fst: Register, snd: Register, name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::CMPR(fst, snd));
         instructions.push(Code::BEQ(name));
     }
 
-    fn jump_label_if_less(
-        &self,
-        fst: Register,
-        snd: Register,
-        name: Name,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn jump_label_if_less(fst: Register, snd: Register, name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::CMPR(fst, snd));
         instructions.push(Code::BLT(name));
     }
 
-    fn jump_label_if_zero(&self, temporary: Register, name: Name, instructions: &mut Vec<Code>) {
+    fn jump_label_if_zero(temporary: Register, name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::CMPI(temporary, 0));
         instructions.push(Code::BEQ(name));
     }
 
-    fn load_immediate(
-        &self,
-        temporary: Register,
-        immediate: Immediate,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn load_immediate(temporary: Register, immediate: Immediate, instructions: &mut Vec<Code>) {
         fn number_unset_halfwords(immediate: Immediate) -> usize {
             let mut unset_halfwords = 0;
             for i in 0..4 {
@@ -368,22 +351,16 @@ impl Instructions<Code, Register, Immediate> for Backend {
         }
     }
 
-    fn load_label(&self, temporary: Register, name: Name, instructions: &mut Vec<Code>) {
+    fn load_label(temporary: Register, name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::ADR(temporary, name));
     }
 
-    fn add_and_jump(
-        &self,
-        temporary: Register,
-        immediate: Immediate,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn add_and_jump(temporary: Register, immediate: Immediate, instructions: &mut Vec<Code>) {
         instructions.push(Code::ADDI(TEMP, temporary, immediate));
         instructions.push(Code::BR(TEMP));
     }
 
     fn add(
-        &self,
         target_temporary: Register,
         source_temporary_1: Register,
         source_temporary_2: Register,
@@ -397,7 +374,6 @@ impl Instructions<Code, Register, Immediate> for Backend {
     }
 
     fn sub(
-        &self,
         target_temporary: Register,
         source_temporary_1: Register,
         source_temporary_2: Register,
@@ -411,7 +387,6 @@ impl Instructions<Code, Register, Immediate> for Backend {
     }
 
     fn mul(
-        &self,
         target_temporary: Register,
         source_temporary_1: Register,
         source_temporary_2: Register,
@@ -425,7 +400,6 @@ impl Instructions<Code, Register, Immediate> for Backend {
     }
 
     fn div(
-        &self,
         target_temporary: Register,
         source_temporary_1: Register,
         source_temporary_2: Register,
@@ -439,7 +413,6 @@ impl Instructions<Code, Register, Immediate> for Backend {
     }
 
     fn rem(
-        &self,
         target_temporary: Register,
         source_temporary_1: Register,
         source_temporary_2: Register,
@@ -454,12 +427,7 @@ impl Instructions<Code, Register, Immediate> for Backend {
         ));
     }
 
-    fn mov(
-        &self,
-        target_temporary: Register,
-        source_temporary: Register,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn mov(target_temporary: Register, source_temporary: Register, instructions: &mut Vec<Code>) {
         instructions.push(Code::MOVR(target_temporary, source_temporary));
     }
 }

--- a/lang/axcut2aarch64/src/config.rs
+++ b/lang/axcut2aarch64/src/config.rs
@@ -79,32 +79,32 @@ pub const fn field_offset(number: TemporaryNumber, i: usize) -> i64 {
 }
 
 impl Config<Register, Immediate> for Backend {
-    fn i64_to_immediate(&self, number: i64) -> Immediate {
+    fn i64_to_immediate(number: i64) -> Immediate {
         number
     }
 
-    fn temp(&self) -> Register {
+    fn temp() -> Register {
         TEMP
     }
 
-    fn heap(&self) -> Register {
+    fn heap() -> Register {
         HEAP
     }
 
-    fn free(&self) -> Register {
+    fn free() -> Register {
         FREE
     }
 
-    fn return1(&self) -> Register {
+    fn return1() -> Register {
         RETURN1
     }
 
-    fn return2(&self) -> Register {
+    fn return2() -> Register {
         RETURN2
     }
 
     #[allow(clippy::cast_possible_wrap)]
-    fn jump_length(&self, n: usize) -> Immediate {
+    fn jump_length(n: usize) -> Immediate {
         4 * n as Immediate
     }
 }

--- a/lang/axcut2aarch64/src/memory.rs
+++ b/lang/axcut2aarch64/src/memory.rs
@@ -46,7 +46,7 @@ fn acquire_block(new_block: Register, additional_temp: Register, instructions: &
                 to_erase,
                 field_offset(Fst, offset),
             ));
-            Backend.erase_block(additional_temp, instructions);
+            Backend::erase_block(additional_temp, instructions);
         }
     }
 
@@ -97,7 +97,7 @@ fn store_field(
     offset: usize,
 ) -> Code {
     Code::STR(
-        Backend.fresh_temporary(number, context),
+        Backend::fresh_temporary(number, context),
         memory_block,
         field_offset(number, offset),
     )
@@ -110,7 +110,7 @@ fn load_field(
     offset: usize,
 ) -> Code {
     Code::LDR(
-        Backend.fresh_temporary(number, context),
+        Backend::fresh_temporary(number, context),
         memory_block,
         field_offset(number, offset),
     )
@@ -154,7 +154,10 @@ fn load_binder(
                 fresh_label();
             }
             LoadMode::Share => {
-                Backend.share_block(Backend.fresh_temporary(Fst, existing_context), instructions);
+                Backend::share_block(
+                    Backend::fresh_temporary(Fst, existing_context),
+                    instructions,
+                );
             }
         }
     }
@@ -253,8 +256,8 @@ fn store_rest(
         );
 
         acquire_block(
-            Backend.fresh_temporary(Fst, &remaining_plus_rest),
-            Backend.fresh_temporary(Snd, &remaining_plus_rest),
+            Backend::fresh_temporary(Fst, &remaining_plus_rest),
+            Backend::fresh_temporary(Snd, &remaining_plus_rest),
             instructions,
         );
 
@@ -288,7 +291,7 @@ fn load_fields_rest(
 
         load_fields_rest(to_load, existing_context, load_mode, instructions);
 
-        let memory_block = Backend.fresh_temporary(Fst, &existing_plus_rest);
+        let memory_block = Backend::fresh_temporary(Fst, &existing_plus_rest);
 
         match load_mode {
             LoadMode::Release => release_block(memory_block, instructions),
@@ -334,7 +337,7 @@ fn load_fields(
 
         load_fields_rest(to_load, existing_context, load_mode, instructions);
 
-        let memory_block = Backend.fresh_temporary(Fst, &existing_plus_rest);
+        let memory_block = Backend::fresh_temporary(Fst, &existing_plus_rest);
 
         match load_mode {
             LoadMode::Release => release_block(memory_block, instructions),
@@ -354,7 +357,7 @@ fn load_fields(
 
 impl Memory<Code, Register> for Backend {
     #[allow(clippy::vec_init_then_push)]
-    fn erase_block(&self, to_erase: Register, instructions: &mut Vec<Code>) {
+    fn erase_block(to_erase: Register, instructions: &mut Vec<Code>) {
         let mut to_skip = Vec::with_capacity(10);
         to_skip.push(Code::LDR(TEMP, to_erase, REFERENCE_COUNT_OFFSET));
 
@@ -373,7 +376,7 @@ impl Memory<Code, Register> for Backend {
 
     #[allow(clippy::vec_init_then_push)]
     #[allow(clippy::cast_possible_wrap)]
-    fn share_block_n(&self, to_share: Register, n: usize, instructions: &mut Vec<Code>) {
+    fn share_block_n(to_share: Register, n: usize, instructions: &mut Vec<Code>) {
         let mut to_skip = Vec::with_capacity(3);
         to_skip.push(Code::LDR(TEMP, to_share, REFERENCE_COUNT_OFFSET));
         to_skip.push(Code::ADDI(TEMP, TEMP, n as Immediate));
@@ -382,13 +385,12 @@ impl Memory<Code, Register> for Backend {
     }
 
     fn load(
-        &self,
         to_load: TypingContext,
         existing_context: &TypingContext,
         instructions: &mut Vec<Code>,
     ) {
         if !to_load.bindings.is_empty() {
-            let memory_block = Backend.fresh_temporary(Fst, existing_context);
+            let memory_block = Backend::fresh_temporary(Fst, existing_context);
 
             instructions.push(Code::LDR(TEMP, memory_block, REFERENCE_COUNT_OFFSET));
 
@@ -410,14 +412,13 @@ impl Memory<Code, Register> for Backend {
     }
 
     fn store(
-        &self,
         mut to_store: TypingContext,
         remaining_context: &TypingContext,
         instructions: &mut Vec<Code>,
     ) {
         if to_store.bindings.is_empty() {
             instructions.push(Code::MOVZ(
-                Backend.fresh_temporary(Fst, remaining_context),
+                Backend::fresh_temporary(Fst, remaining_context),
                 0,
                 0,
             ));
@@ -443,8 +444,8 @@ impl Memory<Code, Register> for Backend {
             );
 
             acquire_block(
-                Backend.fresh_temporary(Fst, &remaining_plus_rest),
-                Backend.fresh_temporary(Snd, &remaining_plus_rest),
+                Backend::fresh_temporary(Fst, &remaining_plus_rest),
+                Backend::fresh_temporary(Snd, &remaining_plus_rest),
                 instructions,
             );
 

--- a/lang/axcut2aarch64/src/parallel_moves.rs
+++ b/lang/axcut2aarch64/src/parallel_moves.rs
@@ -18,7 +18,6 @@ fn tree_moves(register: Register, tree: &Tree<Register>, instructions: &mut Vec<
 
 impl ParallelMoves<Code, Register> for Backend {
     fn root_moves(
-        &self,
         root: axcut2backend::parallel_moves::Root<Register>,
         instructions: &mut Vec<Code>,
     ) {

--- a/lang/axcut2aarch64/src/utils.rs
+++ b/lang/axcut2aarch64/src/utils.rs
@@ -6,7 +6,6 @@ use axcut2backend::{config::TemporaryNumber, utils::Utils};
 
 impl Utils<Register> for Backend {
     fn variable_temporary(
-        &self,
         number: TemporaryNumber,
         context: &TypingContext,
         variable: &Var,
@@ -25,7 +24,7 @@ impl Utils<Register> for Backend {
         Register::X(register_number)
     }
 
-    fn fresh_temporary(&self, number: TemporaryNumber, context: &TypingContext) -> Register {
+    fn fresh_temporary(number: TemporaryNumber, context: &TypingContext) -> Register {
         let variable_position = context.bindings.len();
         let register_number = 2 * variable_position + number as usize + RESERVED;
         assert!(register_number < REGISTER_NUM, "Out of registers");

--- a/lang/axcut2aarch64/tests/arith.rs
+++ b/lang/axcut2aarch64/tests/arith.rs
@@ -74,7 +74,7 @@ fn test_arith() {
         types: vec![],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_aarch64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/arith.aarch64.asm")

--- a/lang/axcut2aarch64/tests/closure.rs
+++ b/lang/axcut2aarch64/tests/closure.rs
@@ -137,7 +137,7 @@ fn test_closure() {
         types: vec![ty_cont, ty_func],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_aarch64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/closure.aarch64.asm")

--- a/lang/axcut2aarch64/tests/either.rs
+++ b/lang/axcut2aarch64/tests/either.rs
@@ -99,7 +99,7 @@ fn test_either() {
         types: vec![ty_either],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_aarch64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/either.aarch64.asm")

--- a/lang/axcut2aarch64/tests/list.rs
+++ b/lang/axcut2aarch64/tests/list.rs
@@ -119,7 +119,7 @@ fn test_list() {
         types: vec![ty_list],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_aarch64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/list.aarch64.asm")

--- a/lang/axcut2aarch64/tests/midi.rs
+++ b/lang/axcut2aarch64/tests/midi.rs
@@ -325,7 +325,7 @@ fn test_midi() {
         types: vec![ty_list, ty_cont_list, ty_cont_int],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_aarch64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/midi.aarch64.asm")

--- a/lang/axcut2aarch64/tests/mini.rs
+++ b/lang/axcut2aarch64/tests/mini.rs
@@ -78,7 +78,7 @@ fn test_mini() {
         types: Vec::new(),
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_aarch64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/mini.aarch64.asm")

--- a/lang/axcut2aarch64/tests/nonLinear.rs
+++ b/lang/axcut2aarch64/tests/nonLinear.rs
@@ -244,7 +244,7 @@ fn test_non_linear() {
         types: vec![ty_box, ty_box_box],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_aarch64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/nonLinear.aarch64.asm")

--- a/lang/axcut2aarch64/tests/quad.rs
+++ b/lang/axcut2aarch64/tests/quad.rs
@@ -127,7 +127,7 @@ fn test_quad() {
         types: vec![ty_quad],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_aarch64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/quad.aarch64.asm")

--- a/lang/axcut2backend/src/code.rs
+++ b/lang/axcut2backend/src/code.rs
@@ -1,77 +1,50 @@
 use axcut::syntax::Name;
 
 pub trait Instructions<Code, Temporary, Immediate> {
-    fn comment(&self, msg: String) -> Code;
-    fn label(&self, name: Name) -> Code;
-    fn jump(&self, temporary: Temporary, instructions: &mut Vec<Code>);
-    fn jump_label(&self, name: Name, instructions: &mut Vec<Code>);
+    fn comment(msg: String) -> Code;
+    fn label(name: Name) -> Code;
+    fn jump(temporary: Temporary, instructions: &mut Vec<Code>);
+    fn jump_label(name: Name, instructions: &mut Vec<Code>);
     fn jump_label_if_equal(
-        &self,
         fst: Temporary,
         snd: Temporary,
         name: Name,
         instructions: &mut Vec<Code>,
     );
-    fn jump_label_if_less(
-        &self,
-        fst: Temporary,
-        snd: Temporary,
-        name: Name,
-        instructions: &mut Vec<Code>,
-    );
-    fn jump_label_if_zero(&self, temporary: Temporary, name: Name, instructions: &mut Vec<Code>);
-    fn load_immediate(
-        &self,
-        temporary: Temporary,
-        immediate: Immediate,
-        instructions: &mut Vec<Code>,
-    );
-    fn load_label(&self, temporary: Temporary, name: Name, instructions: &mut Vec<Code>);
-    fn add_and_jump(
-        &self,
-        temporary: Temporary,
-        immediate: Immediate,
-        instructions: &mut Vec<Code>,
-    );
+    fn jump_label_if_less(fst: Temporary, snd: Temporary, name: Name, instructions: &mut Vec<Code>);
+    fn jump_label_if_zero(temporary: Temporary, name: Name, instructions: &mut Vec<Code>);
+    fn load_immediate(temporary: Temporary, immediate: Immediate, instructions: &mut Vec<Code>);
+    fn load_label(temporary: Temporary, name: Name, instructions: &mut Vec<Code>);
+    fn add_and_jump(temporary: Temporary, immediate: Immediate, instructions: &mut Vec<Code>);
     fn add(
-        &self,
         target_temporary: Temporary,
         source_temporary_1: Temporary,
         source_temporary_2: Temporary,
         instructions: &mut Vec<Code>,
     );
     fn sub(
-        &self,
         target_temporary: Temporary,
         source_temporary_1: Temporary,
         source_temporary_2: Temporary,
         instructions: &mut Vec<Code>,
     );
     fn mul(
-        &self,
         target_temporary: Temporary,
         source_temporary_1: Temporary,
         source_temporary_2: Temporary,
         instructions: &mut Vec<Code>,
     );
     fn div(
-        &self,
         target_temporary: Temporary,
         source_temporary_1: Temporary,
         source_temporary_2: Temporary,
         instructions: &mut Vec<Code>,
     );
     fn rem(
-        &self,
         target_temporary: Temporary,
         source_temporary_1: Temporary,
         source_temporary_2: Temporary,
         instructions: &mut Vec<Code>,
     );
-    fn mov(
-        &self,
-        target_temporary: Temporary,
-        source_temporary: Temporary,
-        instructions: &mut Vec<Code>,
-    );
+    fn mov(target_temporary: Temporary, source_temporary: Temporary, instructions: &mut Vec<Code>);
 }

--- a/lang/axcut2backend/src/coder.rs
+++ b/lang/axcut2backend/src/coder.rs
@@ -10,7 +10,6 @@ const INSTRUCTION_CAPACITY_PER_LABEL: usize = 10000;
 
 fn translate<Backend, Code, Temporary: Ord + Hash + Copy, Immediate>(
     program: Prog,
-    backend: &Backend,
 ) -> Vec<Vec<Code>>
 where
     Backend: Config<Temporary, Immediate>
@@ -23,7 +22,7 @@ where
     for def in program.defs {
         let mut is = Vec::with_capacity(INSTRUCTION_CAPACITY_PER_LABEL);
         def.body
-            .code_statement(&program.types, def.context, backend, &mut is);
+            .code_statement::<Backend, _, _, _>(&program.types, def.context, &mut is);
         is.shrink_to_fit();
         instructions.push(is);
     }
@@ -33,7 +32,6 @@ where
 fn assemble<Backend, Code, Temporary, Immediate>(
     instructions: Vec<Vec<Code>>,
     names: Vec<Name>,
-    backend: &Backend,
 ) -> Vec<Code>
 where
     Backend: Config<Temporary, Immediate>
@@ -45,7 +43,7 @@ where
     let mut flattened_instructions =
         Vec::with_capacity(instructions.len() + instructions.iter().map(Vec::len).sum::<usize>());
     for (mut is, name) in instructions.into_iter().zip(names) {
-        flattened_instructions.push(backend.label(name));
+        flattened_instructions.push(Backend::label(name));
         flattened_instructions.append(&mut is);
     }
     flattened_instructions
@@ -59,7 +57,6 @@ pub struct AssemblyProg<Code> {
 #[must_use]
 pub fn compile<Backend, Code, Temporary: Ord + Hash + Copy, Immediate>(
     program: Prog,
-    backend: &Backend,
 ) -> AssemblyProg<Code>
 where
     Backend: Config<Temporary, Immediate>
@@ -75,7 +72,7 @@ where
 
     let number_of_arguments = program.defs[0].context.bindings.len();
     AssemblyProg {
-        instructions: assemble(translate(program, backend), names, backend),
+        instructions: assemble::<Backend, _, _, _>(translate::<Backend, _, _, _>(program), names),
         number_of_arguments,
     }
 }

--- a/lang/axcut2backend/src/config.rs
+++ b/lang/axcut2backend/src/config.rs
@@ -5,11 +5,11 @@ pub enum TemporaryNumber {
 }
 
 pub trait Config<Temporary, Immediate> {
-    fn i64_to_immediate(&self, number: i64) -> Immediate;
-    fn temp(&self) -> Temporary;
-    fn heap(&self) -> Temporary;
-    fn free(&self) -> Temporary;
-    fn return1(&self) -> Temporary;
-    fn return2(&self) -> Temporary;
-    fn jump_length(&self, n: usize) -> Immediate;
+    fn i64_to_immediate(number: i64) -> Immediate;
+    fn temp() -> Temporary;
+    fn heap() -> Temporary;
+    fn free() -> Temporary;
+    fn return1() -> Temporary;
+    fn return2() -> Temporary;
+    fn jump_length(n: usize) -> Immediate;
 }

--- a/lang/axcut2backend/src/memory.rs
+++ b/lang/axcut2backend/src/memory.rs
@@ -1,19 +1,13 @@
 use axcut::syntax::TypingContext;
 
 pub trait Memory<Code, Temporary> {
-    fn erase_block(&self, to_erase: Temporary, instructions: &mut Vec<Code>);
-    fn share_block_n(&self, to_share: Temporary, n: usize, instructions: &mut Vec<Code>);
-    fn share_block(&self, to_share: Temporary, instructions: &mut Vec<Code>) {
-        self.share_block_n(to_share, 1, instructions);
+    fn erase_block(to_erase: Temporary, instructions: &mut Vec<Code>);
+    fn share_block_n(to_share: Temporary, n: usize, instructions: &mut Vec<Code>);
+    fn share_block(to_share: Temporary, instructions: &mut Vec<Code>) {
+        Self::share_block_n(to_share, 1, instructions);
     }
-    fn load(
-        &self,
-        to_load: TypingContext,
-        existing_context: &TypingContext,
-        instructions: &mut Vec<Code>,
-    );
+    fn load(to_load: TypingContext, existing_context: &TypingContext, instructions: &mut Vec<Code>);
     fn store(
-        &self,
         to_store: TypingContext,
         remaining_context: &TypingContext,
         instructions: &mut Vec<Code>,

--- a/lang/axcut2backend/src/parallel_moves.rs
+++ b/lang/axcut2backend/src/parallel_moves.rs
@@ -102,18 +102,17 @@ fn spanning_forest<Temporary: Ord + Hash + Copy>(
 }
 
 pub trait ParallelMoves<Code, Temporary> {
-    fn root_moves(&self, root: Root<Temporary>, instructions: &mut Vec<Code>);
+    fn root_moves(root: Root<Temporary>, instructions: &mut Vec<Code>);
 }
 
 /// This assumes that the `BTreeSet`s in `assignments` are pairwise disjoint.
 pub fn parallel_moves<Backend, Code, Temporary: Ord + Hash + Copy>(
     assignments: BTreeMap<Temporary, BTreeSet<Temporary>>,
-    backend: &Backend,
     instructions: &mut Vec<Code>,
 ) where
     Backend: ParallelMoves<Code, Temporary>,
 {
     for root in spanning_forest(assignments) {
-        backend.root_moves(root, instructions);
+        Backend::root_moves(root, instructions);
     }
 }

--- a/lang/axcut2backend/src/statements/ifc.rs
+++ b/lang/axcut2backend/src/statements/ifc.rs
@@ -16,7 +16,6 @@ impl CodeStatement for IfC {
         self,
         types: &[TypeDeclaration],
         context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
@@ -27,24 +26,24 @@ impl CodeStatement for IfC {
     {
         let fresh_label = format!("lab{}", fresh_label());
         match self.sort {
-            axcut::syntax::statements::ifc::IfSort::Equal => backend.jump_label_if_equal(
-                backend.variable_temporary(Snd, &context, &self.fst),
-                backend.variable_temporary(Snd, &context, &self.snd),
+            axcut::syntax::statements::ifc::IfSort::Equal => Backend::jump_label_if_equal(
+                Backend::variable_temporary(Snd, &context, &self.fst),
+                Backend::variable_temporary(Snd, &context, &self.snd),
                 fresh_label.clone(),
                 instructions,
             ),
-            axcut::syntax::statements::ifc::IfSort::Less => backend.jump_label_if_less(
-                backend.variable_temporary(Snd, &context, &self.fst),
-                backend.variable_temporary(Snd, &context, &self.snd),
+            axcut::syntax::statements::ifc::IfSort::Less => Backend::jump_label_if_less(
+                Backend::variable_temporary(Snd, &context, &self.fst),
+                Backend::variable_temporary(Snd, &context, &self.snd),
                 fresh_label.clone(),
                 instructions,
             ),
         }
 
         self.elsec
-            .code_statement(types, context.clone(), backend, instructions);
-        instructions.push(backend.label(fresh_label));
+            .code_statement::<Backend, _, _, _>(types, context.clone(), instructions);
+        instructions.push(Backend::label(fresh_label));
         self.thenc
-            .code_statement(types, context, backend, instructions);
+            .code_statement::<Backend, _, _, _>(types, context, instructions);
     }
 }

--- a/lang/axcut2backend/src/statements/ifz.rs
+++ b/lang/axcut2backend/src/statements/ifz.rs
@@ -16,7 +16,6 @@ impl CodeStatement for IfZ {
         self,
         types: &[TypeDeclaration],
         context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
@@ -26,15 +25,15 @@ impl CodeStatement for IfZ {
             + Utils<Temporary>,
     {
         let fresh_label = format!("lab{}", fresh_label());
-        backend.jump_label_if_zero(
-            backend.variable_temporary(Snd, &context, &self.ifc),
+        Backend::jump_label_if_zero(
+            Backend::variable_temporary(Snd, &context, &self.ifc),
             fresh_label.clone(),
             instructions,
         );
         self.elsec
-            .code_statement(types, context.clone(), backend, instructions);
-        instructions.push(backend.label(fresh_label));
+            .code_statement::<Backend, _, _, _>(types, context.clone(), instructions);
+        instructions.push(Backend::label(fresh_label));
         self.thenc
-            .code_statement(types, context, backend, instructions);
+            .code_statement::<Backend, _, _, _>(types, context, instructions);
     }
 }

--- a/lang/axcut2backend/src/statements/invoke.rs
+++ b/lang/axcut2backend/src/statements/invoke.rs
@@ -11,23 +11,22 @@ impl CodeStatement for Invoke {
         self,
         types: &[TypeDeclaration],
         context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
             + Instructions<Code, Temporary, Immediate>
             + Utils<Temporary>,
     {
-        let table_temporary = backend.variable_temporary(Snd, &context, &self.var);
+        let table_temporary = Backend::variable_temporary(Snd, &context, &self.var);
         let type_declaration = self.ty.lookup_type_declaration(types);
         let number_of_clauses = type_declaration.xtors.len();
         if number_of_clauses <= 1 {
-            backend.jump(table_temporary, instructions);
+            Backend::jump(table_temporary, instructions);
         } else {
             let tag_position = type_declaration.xtor_position(&self.tag);
-            backend.add_and_jump(
+            Backend::add_and_jump(
                 table_temporary,
-                backend.jump_length(tag_position),
+                Backend::jump_length(tag_position),
                 instructions,
             );
         }

--- a/lang/axcut2backend/src/statements/leta.rs
+++ b/lang/axcut2backend/src/statements/leta.rs
@@ -15,7 +15,6 @@ impl CodeStatement for Leta {
         self,
         types: &[TypeDeclaration],
         mut context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
@@ -27,7 +26,7 @@ impl CodeStatement for Leta {
         let arguments = context
             .bindings
             .split_off(context.bindings.len() - self.args.len());
-        backend.store(arguments.into(), &context, instructions);
+        Backend::store(arguments.into(), &context, instructions);
         let tag_position = self
             .ty
             .lookup_type_declaration(types)
@@ -37,13 +36,13 @@ impl CodeStatement for Leta {
             chi: Chirality::Prd,
             ty: self.ty,
         });
-        let tag_temporary = backend.variable_temporary(Snd, &context, &self.var);
-        backend.load_immediate(
+        let tag_temporary = Backend::variable_temporary(Snd, &context, &self.var);
+        Backend::load_immediate(
             tag_temporary,
-            backend.jump_length(tag_position),
+            Backend::jump_length(tag_position),
             instructions,
         );
         self.next
-            .code_statement(types, context, backend, instructions);
+            .code_statement::<Backend, _, _, _>(types, context, instructions);
     }
 }

--- a/lang/axcut2backend/src/statements/literal.rs
+++ b/lang/axcut2backend/src/statements/literal.rs
@@ -17,7 +17,6 @@ impl CodeStatement for Literal {
         self,
         types: &[TypeDeclaration],
         mut context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
@@ -31,12 +30,12 @@ impl CodeStatement for Literal {
             chi: Chirality::Ext,
             ty: Ty::Int,
         });
-        backend.load_immediate(
-            backend.variable_temporary(Snd, &context, &self.var),
-            backend.i64_to_immediate(self.lit),
+        Backend::load_immediate(
+            Backend::variable_temporary(Snd, &context, &self.var),
+            Backend::i64_to_immediate(self.lit),
             instructions,
         );
         self.case
-            .code_statement(types, context, backend, instructions);
+            .code_statement::<Backend, _, _, _>(types, context, instructions);
     }
 }

--- a/lang/axcut2backend/src/statements/mod.rs
+++ b/lang/axcut2backend/src/statements/mod.rs
@@ -22,7 +22,6 @@ pub trait CodeStatement {
         self,
         types: &[TypeDeclaration],
         context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
@@ -37,7 +36,6 @@ impl<T: CodeStatement + Clone> CodeStatement for Rc<T> {
         self,
         types: &[TypeDeclaration],
         context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
@@ -46,7 +44,7 @@ impl<T: CodeStatement + Clone> CodeStatement for Rc<T> {
             + ParallelMoves<Code, Temporary>
             + Utils<Temporary>,
     {
-        Rc::unwrap_or_clone(self).code_statement(types, context, backend, instructions);
+        Rc::unwrap_or_clone(self).code_statement::<Backend, _, _, _>(types, context, instructions);
     }
 }
 
@@ -55,7 +53,6 @@ impl CodeStatement for Statement {
         self,
         types: &[TypeDeclaration],
         context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
@@ -66,25 +63,37 @@ impl CodeStatement for Statement {
     {
         match self {
             Statement::Substitute(substitute) => {
-                substitute.code_statement(types, context, backend, instructions);
+                substitute.code_statement::<Backend, _, _, _>(types, context, instructions);
             }
-            Statement::Call(call) => backend.jump_label(call.label, instructions),
-            Statement::Leta(leta) => leta.code_statement(types, context, backend, instructions),
+            Statement::Call(call) => Backend::jump_label(call.label, instructions),
+            Statement::Leta(leta) => {
+                leta.code_statement::<Backend, _, _, _>(types, context, instructions);
+            }
             Statement::Switch(switch) => {
-                switch.code_statement(types, context, backend, instructions);
+                switch.code_statement::<Backend, _, _, _>(types, context, instructions);
             }
-            Statement::New(new) => new.code_statement(types, context, backend, instructions),
+            Statement::New(new) => {
+                new.code_statement::<Backend, _, _, _>(types, context, instructions);
+            }
             Statement::Invoke(invoke) => {
-                invoke.code_statement(types, context, backend, instructions);
+                invoke.code_statement::<Backend, _, _, _>(types, context, instructions);
             }
             Statement::Literal(lit) => {
-                lit.code_statement(types, context, backend, instructions);
+                lit.code_statement::<Backend, _, _, _>(types, context, instructions);
             }
-            Statement::Op(op) => op.code_statement(types, context, backend, instructions),
-            Statement::IfC(ifc) => ifc.code_statement(types, context, backend, instructions),
-            Statement::IfZ(ifz) => ifz.code_statement(types, context, backend, instructions),
-            Statement::Return(ret) => ret.code_statement(types, context, backend, instructions),
-            Statement::Done => backend.jump_label("cleanup".to_string(), instructions),
+            Statement::Op(op) => {
+                op.code_statement::<Backend, _, _, _>(types, context, instructions);
+            }
+            Statement::IfC(ifc) => {
+                ifc.code_statement::<Backend, _, _, _>(types, context, instructions);
+            }
+            Statement::IfZ(ifz) => {
+                ifz.code_statement::<Backend, _, _, _>(types, context, instructions);
+            }
+            Statement::Return(ret) => {
+                ret.code_statement::<Backend, _, _, _>(types, context, instructions);
+            }
+            Statement::Done => Backend::jump_label("cleanup".to_string(), instructions),
         }
     }
 }

--- a/lang/axcut2backend/src/statements/op.rs
+++ b/lang/axcut2backend/src/statements/op.rs
@@ -17,7 +17,6 @@ impl CodeStatement for Op {
         self,
         types: &[TypeDeclaration],
         mut context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
@@ -31,40 +30,40 @@ impl CodeStatement for Op {
             chi: Chirality::Ext,
             ty: Ty::Int,
         });
-        let target_temporary = backend.variable_temporary(Snd, &context, &self.var);
+        let target_temporary = Backend::variable_temporary(Snd, &context, &self.var);
         match self.op {
-            BinOp::Sum => backend.add(
+            BinOp::Sum => Backend::add(
                 target_temporary,
-                backend.variable_temporary(Snd, &context, &self.fst),
-                backend.variable_temporary(Snd, &context, &self.snd),
+                Backend::variable_temporary(Snd, &context, &self.fst),
+                Backend::variable_temporary(Snd, &context, &self.snd),
                 instructions,
             ),
-            BinOp::Sub => backend.sub(
+            BinOp::Sub => Backend::sub(
                 target_temporary,
-                backend.variable_temporary(Snd, &context, &self.fst),
-                backend.variable_temporary(Snd, &context, &self.snd),
+                Backend::variable_temporary(Snd, &context, &self.fst),
+                Backend::variable_temporary(Snd, &context, &self.snd),
                 instructions,
             ),
-            BinOp::Prod => backend.mul(
+            BinOp::Prod => Backend::mul(
                 target_temporary,
-                backend.variable_temporary(Snd, &context, &self.fst),
-                backend.variable_temporary(Snd, &context, &self.snd),
+                Backend::variable_temporary(Snd, &context, &self.fst),
+                Backend::variable_temporary(Snd, &context, &self.snd),
                 instructions,
             ),
-            BinOp::Div => backend.div(
+            BinOp::Div => Backend::div(
                 target_temporary,
-                backend.variable_temporary(Snd, &context, &self.fst),
-                backend.variable_temporary(Snd, &context, &self.snd),
+                Backend::variable_temporary(Snd, &context, &self.fst),
+                Backend::variable_temporary(Snd, &context, &self.snd),
                 instructions,
             ),
-            BinOp::Rem => backend.rem(
+            BinOp::Rem => Backend::rem(
                 target_temporary,
-                backend.variable_temporary(Snd, &context, &self.fst),
-                backend.variable_temporary(Snd, &context, &self.snd),
+                Backend::variable_temporary(Snd, &context, &self.fst),
+                Backend::variable_temporary(Snd, &context, &self.snd),
                 instructions,
             ),
         }
         self.case
-            .code_statement(types, context, backend, instructions);
+            .code_statement::<Backend, _, _, _>(types, context, instructions);
     }
 }

--- a/lang/axcut2backend/src/statements/ret.rs
+++ b/lang/axcut2backend/src/statements/ret.rs
@@ -11,18 +11,17 @@ impl CodeStatement for Return {
         self,
         _types: &[TypeDeclaration],
         context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
             + Instructions<Code, Temporary, Immediate>
             + Utils<Temporary>,
     {
-        backend.mov(
-            backend.return2(),
-            backend.variable_temporary(Snd, &context, &self.var),
+        Backend::mov(
+            Backend::return2(),
+            Backend::variable_temporary(Snd, &context, &self.var),
             instructions,
         );
-        backend.jump_label("cleanup".to_string(), instructions);
+        Backend::jump_label("cleanup".to_string(), instructions);
     }
 }

--- a/lang/axcut2backend/src/statements/substitute.rs
+++ b/lang/axcut2backend/src/statements/substitute.rs
@@ -12,7 +12,6 @@ impl CodeStatement for Substitute {
         self,
         types: &[TypeDeclaration],
         context: TypingContext,
-        backend: &Backend,
         instructions: &mut Vec<Code>,
     ) where
         Backend: Config<Temporary, Immediate>
@@ -41,9 +40,9 @@ impl CodeStatement for Substitute {
             })
             .collect::<Vec<_>>()
             .into();
-        code_weakening_contraction(&target_map, &context, backend, instructions);
-        code_exchange(&target_map, &context, &new_context, backend, instructions);
+        code_weakening_contraction::<Backend, _, _, _>(&target_map, &context, instructions);
+        code_exchange::<Backend, _, _, _>(&target_map, &context, &new_context, instructions);
         self.next
-            .code_statement(types, new_context, backend, instructions);
+            .code_statement::<Backend, _, _, _>(types, new_context, instructions);
     }
 }

--- a/lang/axcut2rv64/src/code.rs
+++ b/lang/axcut2rv64/src/code.rs
@@ -53,71 +53,48 @@ impl std::fmt::Display for Code {
 }
 
 impl Instructions<Code, Register, Immediate> for Backend {
-    fn comment(&self, msg: String) -> Code {
+    fn comment(msg: String) -> Code {
         Code::COMMENT(msg)
     }
 
-    fn label(&self, name: Name) -> Code {
+    fn label(name: Name) -> Code {
         Code::LAB(name)
     }
 
-    fn jump(&self, temporary: Register, instructions: &mut Vec<Code>) {
+    fn jump(temporary: Register, instructions: &mut Vec<Code>) {
         instructions.push(Code::JALR(ZERO, temporary, 0));
     }
 
-    fn jump_label(&self, name: Name, instructions: &mut Vec<Code>) {
+    fn jump_label(name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::JAL(ZERO, name));
     }
 
-    fn jump_label_if_equal(
-        &self,
-        fst: Register,
-        snd: Register,
-        name: Name,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn jump_label_if_equal(fst: Register, snd: Register, name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::BEQ(fst, snd, name));
     }
 
-    fn jump_label_if_less(
-        &self,
-        fst: Register,
-        snd: Register,
-        name: Name,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn jump_label_if_less(fst: Register, snd: Register, name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::BLT(fst, snd, name));
     }
 
-    fn jump_label_if_zero(&self, temporary: Register, name: Name, instructions: &mut Vec<Code>) {
+    fn jump_label_if_zero(temporary: Register, name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::BEQ(temporary, ZERO, name));
     }
 
-    fn load_immediate(
-        &self,
-        temporary: Register,
-        immediate: Immediate,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn load_immediate(temporary: Register, immediate: Immediate, instructions: &mut Vec<Code>) {
         instructions.push(Code::LI(temporary, immediate));
     }
 
-    fn load_label(&self, temporary: Register, name: Name, instructions: &mut Vec<Code>) {
+    fn load_label(temporary: Register, name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::LA(temporary, name));
     }
 
-    fn add_and_jump(
-        &self,
-        temporary: Register,
-        immediate: Immediate,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn add_and_jump(temporary: Register, immediate: Immediate, instructions: &mut Vec<Code>) {
         instructions.push(Code::ADDI(TEMP, temporary, immediate));
         instructions.push(Code::JALR(ZERO, TEMP, 0));
     }
 
     fn add(
-        &self,
         target_temporary: Register,
         source_temporary_1: Register,
         source_temporary_2: Register,
@@ -131,7 +108,6 @@ impl Instructions<Code, Register, Immediate> for Backend {
     }
 
     fn sub(
-        &self,
         target_temporary: Register,
         source_temporary_1: Register,
         source_temporary_2: Register,
@@ -145,7 +121,6 @@ impl Instructions<Code, Register, Immediate> for Backend {
     }
 
     fn mul(
-        &self,
         target_temporary: Register,
         source_temporary_1: Register,
         source_temporary_2: Register,
@@ -159,7 +134,6 @@ impl Instructions<Code, Register, Immediate> for Backend {
     }
 
     fn div(
-        &self,
         target_temporary: Register,
         source_temporary_1: Register,
         source_temporary_2: Register,
@@ -173,7 +147,6 @@ impl Instructions<Code, Register, Immediate> for Backend {
     }
 
     fn rem(
-        &self,
         target_temporary: Register,
         source_temporary_1: Register,
         source_temporary_2: Register,
@@ -186,12 +159,7 @@ impl Instructions<Code, Register, Immediate> for Backend {
         ));
     }
 
-    fn mov(
-        &self,
-        target_temporary: Register,
-        source_temporary: Register,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn mov(target_temporary: Register, source_temporary: Register, instructions: &mut Vec<Code>) {
         instructions.push(Code::MV(target_temporary, source_temporary));
     }
 }

--- a/lang/axcut2rv64/src/config.rs
+++ b/lang/axcut2rv64/src/config.rs
@@ -57,32 +57,32 @@ pub const fn field_offset(number: TemporaryNumber, i: usize) -> i64 {
 }
 
 impl Config<Register, Immediate> for Backend {
-    fn i64_to_immediate(&self, number: i64) -> Immediate {
+    fn i64_to_immediate(number: i64) -> Immediate {
         number
     }
 
-    fn temp(&self) -> Register {
+    fn temp() -> Register {
         TEMP
     }
 
-    fn heap(&self) -> Register {
+    fn heap() -> Register {
         HEAP
     }
 
-    fn free(&self) -> Register {
+    fn free() -> Register {
         FREE
     }
 
-    fn return1(&self) -> Register {
+    fn return1() -> Register {
         RETURN1
     }
 
-    fn return2(&self) -> Register {
+    fn return2() -> Register {
         RETURN2
     }
 
     #[allow(clippy::cast_possible_wrap)]
-    fn jump_length(&self, n: usize) -> Immediate {
+    fn jump_length(n: usize) -> Immediate {
         4 * n as Immediate
     }
 }

--- a/lang/axcut2rv64/src/memory.rs
+++ b/lang/axcut2rv64/src/memory.rs
@@ -44,7 +44,7 @@ fn acquire_block(new_block: Register, additional_temp: Register, instructions: &
                 to_erase,
                 field_offset(Fst, offset),
             ));
-            Backend.erase_block(additional_temp, instructions);
+            Backend::erase_block(additional_temp, instructions);
         }
     }
 
@@ -92,7 +92,7 @@ fn store_field(
     offset: usize,
 ) -> Code {
     Code::SW(
-        Backend.fresh_temporary(number, context),
+        Backend::fresh_temporary(number, context),
         memory_block,
         field_offset(number, offset),
     )
@@ -105,7 +105,7 @@ fn load_field(
     offset: usize,
 ) -> Code {
     Code::LW(
-        Backend.fresh_temporary(number, context),
+        Backend::fresh_temporary(number, context),
         memory_block,
         field_offset(number, offset),
     )
@@ -146,7 +146,10 @@ fn load_binder(
         match load_mode {
             LoadMode::Release => {}
             LoadMode::Share => {
-                Backend.share_block(Backend.fresh_temporary(Fst, existing_context), instructions);
+                Backend::share_block(
+                    Backend::fresh_temporary(Fst, existing_context),
+                    instructions,
+                );
             }
         }
     }
@@ -245,8 +248,8 @@ fn store_rest(
         );
 
         acquire_block(
-            Backend.fresh_temporary(Fst, &remaining_plus_rest),
-            Backend.fresh_temporary(Snd, &remaining_plus_rest),
+            Backend::fresh_temporary(Fst, &remaining_plus_rest),
+            Backend::fresh_temporary(Snd, &remaining_plus_rest),
             instructions,
         );
 
@@ -280,7 +283,7 @@ fn load_fields_rest(
 
         load_fields_rest(to_load, existing_context, load_mode, instructions);
 
-        let memory_block = Backend.fresh_temporary(Fst, &existing_plus_rest);
+        let memory_block = Backend::fresh_temporary(Fst, &existing_plus_rest);
 
         match load_mode {
             LoadMode::Release => release_block(memory_block, instructions),
@@ -326,7 +329,7 @@ fn load_fields(
 
         load_fields_rest(to_load, existing_context, load_mode, instructions);
 
-        let memory_block = Backend.fresh_temporary(Fst, &existing_plus_rest);
+        let memory_block = Backend::fresh_temporary(Fst, &existing_plus_rest);
 
         match load_mode {
             LoadMode::Release => release_block(memory_block, instructions),
@@ -346,7 +349,7 @@ fn load_fields(
 
 impl Memory<Code, Register> for Backend {
     #[allow(clippy::vec_init_then_push)]
-    fn erase_block(&self, to_erase: Register, instructions: &mut Vec<Code>) {
+    fn erase_block(to_erase: Register, instructions: &mut Vec<Code>) {
         let mut to_skip = Vec::with_capacity(10);
         to_skip.push(Code::LW(TEMP, to_erase, REFERENCE_COUNT_OFFSET));
 
@@ -365,7 +368,7 @@ impl Memory<Code, Register> for Backend {
 
     #[allow(clippy::vec_init_then_push)]
     #[allow(clippy::cast_possible_wrap)]
-    fn share_block_n(&self, to_share: Register, n: usize, instructions: &mut Vec<Code>) {
+    fn share_block_n(to_share: Register, n: usize, instructions: &mut Vec<Code>) {
         let mut to_skip = Vec::with_capacity(3);
         to_skip.push(Code::LW(TEMP, to_share, REFERENCE_COUNT_OFFSET));
         to_skip.push(Code::ADDI(TEMP, TEMP, n as Immediate));
@@ -374,13 +377,12 @@ impl Memory<Code, Register> for Backend {
     }
 
     fn load(
-        &self,
         to_load: TypingContext,
         existing_context: &TypingContext,
         instructions: &mut Vec<Code>,
     ) {
         if !to_load.bindings.is_empty() {
-            let memory_block = Backend.fresh_temporary(Fst, existing_context);
+            let memory_block = Backend::fresh_temporary(Fst, existing_context);
 
             instructions.push(Code::LW(TEMP, memory_block, REFERENCE_COUNT_OFFSET));
 
@@ -402,14 +404,13 @@ impl Memory<Code, Register> for Backend {
     }
 
     fn store(
-        &self,
         mut to_store: TypingContext,
         remaining_context: &TypingContext,
         instructions: &mut Vec<Code>,
     ) {
         if to_store.bindings.is_empty() {
             instructions.push(Code::MV(
-                Backend.fresh_temporary(Fst, remaining_context),
+                Backend::fresh_temporary(Fst, remaining_context),
                 ZERO,
             ));
         } else {
@@ -434,8 +435,8 @@ impl Memory<Code, Register> for Backend {
             );
 
             acquire_block(
-                Backend.fresh_temporary(Fst, &remaining_plus_rest),
-                Backend.fresh_temporary(Snd, &remaining_plus_rest),
+                Backend::fresh_temporary(Fst, &remaining_plus_rest),
+                Backend::fresh_temporary(Snd, &remaining_plus_rest),
                 instructions,
             );
 

--- a/lang/axcut2rv64/src/parallel_moves.rs
+++ b/lang/axcut2rv64/src/parallel_moves.rs
@@ -18,7 +18,6 @@ fn tree_moves(register: Register, tree: &Tree<Register>, instructions: &mut Vec<
 
 impl ParallelMoves<Code, Register> for Backend {
     fn root_moves(
-        &self,
         root: axcut2backend::parallel_moves::Root<Register>,
         instructions: &mut Vec<Code>,
     ) {

--- a/lang/axcut2rv64/src/utils.rs
+++ b/lang/axcut2rv64/src/utils.rs
@@ -6,7 +6,6 @@ use axcut2backend::{config::TemporaryNumber, utils::Utils};
 
 impl Utils<Register> for Backend {
     fn variable_temporary(
-        &self,
         number: TemporaryNumber,
         context: &TypingContext,
         variable: &Var,
@@ -25,7 +24,7 @@ impl Utils<Register> for Backend {
         Register(register_number)
     }
 
-    fn fresh_temporary(&self, number: TemporaryNumber, context: &TypingContext) -> Register {
+    fn fresh_temporary(number: TemporaryNumber, context: &TypingContext) -> Register {
         let variable_position = context.bindings.len();
         let register_number = 2 * variable_position + number as usize + RESERVED;
         assert!(register_number < REGISTER_NUM, "Out of registers");

--- a/lang/axcut2rv64/tests/arith.rs
+++ b/lang/axcut2rv64/tests/arith.rs
@@ -73,7 +73,7 @@ fn test_arith() {
         types: vec![],
     };
 
-    let assembler_prog = compile(program, &Backend);
+    let assembler_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_rv64_routine(assembler_prog);
 
     //let mut file = File::create("tests/asm/arith.rv64.asm")

--- a/lang/axcut2rv64/tests/closure.rs
+++ b/lang/axcut2rv64/tests/closure.rs
@@ -136,7 +136,7 @@ fn test_closure() {
         types: vec![ty_cont, ty_func],
     };
 
-    let assembler_prog = compile(program, &Backend);
+    let assembler_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_rv64_routine(assembler_prog);
 
     //let mut file = File::create("tests/asm/closure.rv64.asm")

--- a/lang/axcut2rv64/tests/either.rs
+++ b/lang/axcut2rv64/tests/either.rs
@@ -98,7 +98,7 @@ fn test_either() {
         types: vec![ty_either],
     };
 
-    let assembler_prog = compile(program, &Backend);
+    let assembler_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_rv64_routine(assembler_prog);
 
     //let mut file = File::create("tests/asm/either.rv64.asm")

--- a/lang/axcut2rv64/tests/list.rs
+++ b/lang/axcut2rv64/tests/list.rs
@@ -118,7 +118,7 @@ fn test_list() {
         types: vec![ty_list],
     };
 
-    let assembler_prog = compile(program, &Backend);
+    let assembler_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_rv64_routine(assembler_prog);
 
     //let mut file = File::create("tests/asm/list.rv64.asm")

--- a/lang/axcut2rv64/tests/midi.rs
+++ b/lang/axcut2rv64/tests/midi.rs
@@ -324,7 +324,7 @@ fn test_midi() {
         types: vec![ty_list, ty_cont_list, ty_cont_int],
     };
 
-    let assembler_prog = compile(program, &Backend);
+    let assembler_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_rv64_routine(assembler_prog);
 
     //let mut file = File::create("tests/asm/midi.rv64.asm")

--- a/lang/axcut2rv64/tests/mini.rs
+++ b/lang/axcut2rv64/tests/mini.rs
@@ -77,7 +77,7 @@ fn test_mini() {
         types: Vec::new(),
     };
 
-    let assembler_prog = compile(program, &Backend);
+    let assembler_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_rv64_routine(assembler_prog);
 
     //let mut file = File::create("tests/asm/mini.rv64.asm")

--- a/lang/axcut2rv64/tests/nonLinear.rs
+++ b/lang/axcut2rv64/tests/nonLinear.rs
@@ -243,7 +243,7 @@ fn test_non_linear() {
         types: vec![ty_box, ty_box_box],
     };
 
-    let assembler_prog = compile(program, &Backend);
+    let assembler_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_rv64_routine(assembler_prog);
 
     //let mut file = File::create("tests/asm/nonLinear.rv64.asm")

--- a/lang/axcut2rv64/tests/quad.rs
+++ b/lang/axcut2rv64/tests/quad.rs
@@ -126,7 +126,7 @@ fn test_quad() {
         types: vec![ty_quad],
     };
 
-    let assembler_prog = compile(program, &Backend);
+    let assembler_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_rv64_routine(assembler_prog);
 
     //let mut file = File::create("tests/asm/quad.rv64.asm")

--- a/lang/axcut2x86_64/src/code.rs
+++ b/lang/axcut2x86_64/src/code.rs
@@ -459,15 +459,15 @@ pub fn compare_immediate(temporary: Temporary, immediate: Immediate, instruction
 }
 
 impl Instructions<Code, Temporary, Immediate> for Backend {
-    fn comment(&self, msg: String) -> Code {
+    fn comment(msg: String) -> Code {
         Code::COMMENT(msg)
     }
 
-    fn label(&self, name: Name) -> Code {
+    fn label(name: Name) -> Code {
         Code::LAB(name)
     }
 
-    fn jump(&self, temporary: Temporary, instructions: &mut Vec<Code>) {
+    fn jump(temporary: Temporary, instructions: &mut Vec<Code>) {
         match temporary {
             Temporary::Register(register) => instructions.push(Code::JMP(register)),
             Temporary::Spill(position) => {
@@ -477,12 +477,11 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
         }
     }
 
-    fn jump_label(&self, name: Name, instructions: &mut Vec<Code>) {
+    fn jump_label(name: Name, instructions: &mut Vec<Code>) {
         instructions.push(Code::JMPL(name));
     }
 
     fn jump_label_if_equal(
-        &self,
         fst: Temporary,
         snd: Temporary,
         name: Name,
@@ -493,7 +492,6 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
     }
 
     fn jump_label_if_less(
-        &self,
         fst: Temporary,
         snd: Temporary,
         name: Name,
@@ -503,17 +501,12 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
         instructions.push(Code::JLTL(name));
     }
 
-    fn jump_label_if_zero(&self, temporary: Temporary, name: Name, instructions: &mut Vec<Code>) {
+    fn jump_label_if_zero(temporary: Temporary, name: Name, instructions: &mut Vec<Code>) {
         compare_immediate(temporary, 0, instructions);
         instructions.push(Code::JEL(name));
     }
 
-    fn load_immediate(
-        &self,
-        temporary: Temporary,
-        immediate: Immediate,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn load_immediate(temporary: Temporary, immediate: Immediate, instructions: &mut Vec<Code>) {
         match temporary {
             Temporary::Register(register) => instructions.push(Code::MOVI(register, immediate)),
             Temporary::Spill(position) => {
@@ -522,7 +515,7 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
         }
     }
 
-    fn load_label(&self, temporary: Temporary, name: Name, instructions: &mut Vec<Code>) {
+    fn load_label(temporary: Temporary, name: Name, instructions: &mut Vec<Code>) {
         match temporary {
             Temporary::Register(register) => instructions.push(Code::LEAL(register, name)),
             Temporary::Spill(position) => {
@@ -532,12 +525,7 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
         }
     }
 
-    fn add_and_jump(
-        &self,
-        temporary: Temporary,
-        immediate: Immediate,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn add_and_jump(temporary: Temporary, immediate: Immediate, instructions: &mut Vec<Code>) {
         match temporary {
             Temporary::Register(register) => {
                 instructions.push(Code::ADDI(register, immediate));
@@ -552,7 +540,6 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
     }
 
     fn add(
-        &self,
         target_temporary: Temporary,
         source_temporary_1: Temporary,
         source_temporary_2: Temporary,
@@ -568,7 +555,6 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
     }
 
     fn sub(
-        &self,
         target_temporary: Temporary,
         source_temporary_1: Temporary,
         source_temporary_2: Temporary,
@@ -584,7 +570,6 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
     }
 
     fn mul(
-        &self,
         target_temporary: Temporary,
         source_temporary_1: Temporary,
         source_temporary_2: Temporary,
@@ -600,7 +585,6 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
     }
 
     fn div(
-        &self,
         target_temporary: Temporary,
         source_temporary_1: Temporary,
         source_temporary_2: Temporary,
@@ -617,7 +601,6 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
     }
 
     fn rem(
-        &self,
         target_temporary: Temporary,
         source_temporary_1: Temporary,
         source_temporary_2: Temporary,
@@ -632,12 +615,7 @@ impl Instructions<Code, Temporary, Immediate> for Backend {
         instructions.push(Code::MOV(RETURN2, TEMP));
     }
 
-    fn mov(
-        &self,
-        target_temporary: Temporary,
-        source_temporary: Temporary,
-        instructions: &mut Vec<Code>,
-    ) {
+    fn mov(target_temporary: Temporary, source_temporary: Temporary, instructions: &mut Vec<Code>) {
         match (source_temporary, target_temporary) {
             (Temporary::Register(source_register), Temporary::Register(target_register)) => {
                 instructions.push(Code::MOV(target_register, source_register));

--- a/lang/axcut2x86_64/src/config.rs
+++ b/lang/axcut2x86_64/src/config.rs
@@ -137,27 +137,27 @@ pub fn arg(number: usize) -> Register {
 }
 
 impl Config<Temporary, Immediate> for Backend {
-    fn i64_to_immediate(&self, number: i64) -> Immediate {
+    fn i64_to_immediate(number: i64) -> Immediate {
         number
     }
 
-    fn temp(&self) -> Temporary {
+    fn temp() -> Temporary {
         Temporary::Register(TEMP)
     }
 
-    fn heap(&self) -> Temporary {
+    fn heap() -> Temporary {
         Temporary::Register(HEAP)
     }
 
-    fn free(&self) -> Temporary {
+    fn free() -> Temporary {
         Temporary::Register(FREE)
     }
 
-    fn return1(&self) -> Temporary {
+    fn return1() -> Temporary {
         Temporary::Register(RETURN1)
     }
 
-    fn return2(&self) -> Temporary {
+    fn return2() -> Temporary {
         Temporary::Register(RETURN2)
     }
 
@@ -169,7 +169,7 @@ impl Config<Temporary, Immediate> for Backend {
     //                to account for the different lengths of instructions in the jump table
     //                (all 5 bytes except last 64 which are 2 bytes)
     #[allow(clippy::cast_possible_wrap)]
-    fn jump_length(&self, n: usize) -> Immediate {
+    fn jump_length(n: usize) -> Immediate {
         2 * n as Immediate
     }
 }

--- a/lang/axcut2x86_64/src/memory.rs
+++ b/lang/axcut2x86_64/src/memory.rs
@@ -49,7 +49,7 @@ fn acquire_block(new_block: Temporary, instructions: &mut Vec<Code>) {
         // reversed order in iterator to adhere to Idris implementation
         for offset in (0..FIELDS_PER_BLOCK).rev() {
             instructions.push(Code::MOVL(TEMP, to_erase, field_offset(Fst, offset)));
-            Backend.erase_block(Temporary::Register(TEMP), instructions);
+            Backend::erase_block(Temporary::Register(TEMP), instructions);
         }
     }
 
@@ -126,7 +126,7 @@ fn store_field(
     offset: usize,
     instructions: &mut Vec<Code>,
 ) {
-    match Backend.fresh_temporary(number, context) {
+    match Backend::fresh_temporary(number, context) {
         Temporary::Register(register) => instructions.push(Code::MOVS(
             register,
             memory_block,
@@ -146,7 +146,7 @@ fn load_field(
     offset: usize,
     instructions: &mut Vec<Code>,
 ) {
-    match Backend.fresh_temporary(number, context) {
+    match Backend::fresh_temporary(number, context) {
         Temporary::Register(register) => {
             instructions.push(Code::MOVL(
                 register,
@@ -193,7 +193,7 @@ fn load_binder(
     load_field(Snd, existing_context, memory_block, offset, instructions);
     if to_load.chi != Chirality::Ext {
         load_field(Fst, existing_context, memory_block, offset, instructions);
-        let register_to_share = match Backend.fresh_temporary(Fst, existing_context) {
+        let register_to_share = match Backend::fresh_temporary(Fst, existing_context) {
             Temporary::Register(register) => register,
             // if field was loaded to spill position, it is still in `TEMP` here
             Temporary::Spill(_) => TEMP,
@@ -204,7 +204,7 @@ fn load_binder(
                 fresh_label();
             }
             LoadMode::Share => {
-                Backend.share_block(Temporary::Register(register_to_share), instructions);
+                Backend::share_block(Temporary::Register(register_to_share), instructions);
             }
         }
     }
@@ -304,7 +304,7 @@ fn store_rest(
         );
 
         acquire_block(
-            Backend.fresh_temporary(Fst, &remaining_plus_rest),
+            Backend::fresh_temporary(Fst, &remaining_plus_rest),
             instructions,
         );
 
@@ -345,7 +345,7 @@ fn load_fields_rest(
             instructions,
         );
 
-        let memory_block = Backend.fresh_temporary(Fst, &existing_plus_rest);
+        let memory_block = Backend::fresh_temporary(Fst, &existing_plus_rest);
 
         match memory_block {
             Temporary::Register(memory_block_register) => {
@@ -441,7 +441,7 @@ fn load_fields(
             instructions,
         );
 
-        let memory_block = Backend.fresh_temporary(Fst, &existing_plus_rest);
+        let memory_block = Backend::fresh_temporary(Fst, &existing_plus_rest);
 
         match memory_block {
             Temporary::Register(memory_block_register) => {
@@ -492,7 +492,7 @@ fn load_fields(
 }
 
 impl Memory<Code, Temporary> for Backend {
-    fn erase_block(&self, to_erase: Temporary, instructions: &mut Vec<Code>) {
+    fn erase_block(to_erase: Temporary, instructions: &mut Vec<Code>) {
         #[allow(clippy::vec_init_then_push)]
         fn erase_valid_object(to_erase: Register, instructions: &mut Vec<Code>) {
             let mut then_branch = Vec::with_capacity(2);
@@ -527,7 +527,7 @@ impl Memory<Code, Temporary> for Backend {
     }
 
     #[allow(clippy::cast_possible_wrap)]
-    fn share_block_n(&self, to_share: Temporary, n: usize, instructions: &mut Vec<Code>) {
+    fn share_block_n(to_share: Temporary, n: usize, instructions: &mut Vec<Code>) {
         let mut to_skip = Vec::with_capacity(4);
         match to_share {
             Temporary::Register(to_share_register) => {
@@ -547,7 +547,6 @@ impl Memory<Code, Temporary> for Backend {
     }
 
     fn load(
-        &self,
         to_load: TypingContext,
         existing_context: &TypingContext,
         instructions: &mut Vec<Code>,
@@ -580,7 +579,7 @@ impl Memory<Code, Temporary> for Backend {
         }
 
         if !to_load.bindings.is_empty() {
-            let memory_block = Backend.fresh_temporary(Fst, existing_context);
+            let memory_block = Backend::fresh_temporary(Fst, existing_context);
 
             match memory_block {
                 Temporary::Register(memory_block_register) => load_register(
@@ -598,14 +597,13 @@ impl Memory<Code, Temporary> for Backend {
     }
 
     fn store(
-        &self,
         mut to_store: TypingContext,
         remaining_context: &TypingContext,
         instructions: &mut Vec<Code>,
     ) {
         if to_store.bindings.is_empty() {
-            Backend.load_immediate(
-                Backend.fresh_temporary(Fst, remaining_context),
+            Backend::load_immediate(
+                Backend::fresh_temporary(Fst, remaining_context),
                 0,
                 instructions,
             );
@@ -631,7 +629,7 @@ impl Memory<Code, Temporary> for Backend {
             );
 
             acquire_block(
-                Backend.fresh_temporary(Fst, &remaining_plus_rest),
+                Backend::fresh_temporary(Fst, &remaining_plus_rest),
                 instructions,
             );
 

--- a/lang/axcut2x86_64/src/parallel_moves.rs
+++ b/lang/axcut2x86_64/src/parallel_moves.rs
@@ -132,7 +132,6 @@ fn tree_moves(
 
 impl ParallelMoves<Code, Temporary> for Backend {
     fn root_moves(
-        &self,
         root: axcut2backend::parallel_moves::Root<Temporary>,
         instructions: &mut Vec<Code>,
     ) {

--- a/lang/axcut2x86_64/src/utils.rs
+++ b/lang/axcut2x86_64/src/utils.rs
@@ -8,7 +8,6 @@ use axcut2backend::{config::TemporaryNumber, utils::Utils};
 
 impl Utils<Temporary> for Backend {
     fn variable_temporary(
-        &self,
         number: TemporaryNumber,
         context: &TypingContext,
         variable: &Var,
@@ -32,7 +31,7 @@ impl Utils<Temporary> for Backend {
         }
     }
 
-    fn fresh_temporary(&self, number: TemporaryNumber, context: &TypingContext) -> Temporary {
+    fn fresh_temporary(number: TemporaryNumber, context: &TypingContext) -> Temporary {
         let position = 2 * context.bindings.len() + number as usize;
         let register_number = position + RESERVED;
         if register_number < REGISTER_NUM {

--- a/lang/axcut2x86_64/tests/arith.rs
+++ b/lang/axcut2x86_64/tests/arith.rs
@@ -74,7 +74,7 @@ fn test_arith() {
         types: vec![],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_x86_64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/arith.x86_64.asm")

--- a/lang/axcut2x86_64/tests/closure.rs
+++ b/lang/axcut2x86_64/tests/closure.rs
@@ -137,7 +137,7 @@ fn test_closure() {
         types: vec![ty_cont, ty_func],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_x86_64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/closure.x86_64.asm")

--- a/lang/axcut2x86_64/tests/either.rs
+++ b/lang/axcut2x86_64/tests/either.rs
@@ -99,7 +99,7 @@ fn test_either() {
         types: vec![ty_either],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_x86_64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/either.x86_64.asm")

--- a/lang/axcut2x86_64/tests/list.rs
+++ b/lang/axcut2x86_64/tests/list.rs
@@ -119,7 +119,7 @@ fn test_list() {
         types: vec![ty_list],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_x86_64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/list.x86_64.asm")

--- a/lang/axcut2x86_64/tests/midi.rs
+++ b/lang/axcut2x86_64/tests/midi.rs
@@ -325,7 +325,7 @@ fn test_midi() {
         types: vec![ty_list, ty_cont_list, ty_cont_int],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_x86_64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/midi.x86_64.asm")

--- a/lang/axcut2x86_64/tests/mini.rs
+++ b/lang/axcut2x86_64/tests/mini.rs
@@ -78,7 +78,7 @@ fn test_mini() {
         types: Vec::new(),
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_x86_64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/mini.x86_64.asm")

--- a/lang/axcut2x86_64/tests/nonLinear.rs
+++ b/lang/axcut2x86_64/tests/nonLinear.rs
@@ -244,7 +244,7 @@ fn test_non_linear() {
         types: vec![ty_box, ty_box_box],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_x86_64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/nonLinear.x86_64.asm")

--- a/lang/axcut2x86_64/tests/quad.rs
+++ b/lang/axcut2x86_64/tests/quad.rs
@@ -127,7 +127,7 @@ fn test_quad() {
         types: vec![ty_quad],
     };
 
-    let assembly_prog = compile(program, &Backend);
+    let assembly_prog = compile::<Backend, _, _, _>(program);
     let assembler_code = into_x86_64_routine(assembly_prog);
 
     //let mut file = File::create("tests/asm/quad.x86_64.asm")

--- a/lang/driver/src/backends/aarch64.rs
+++ b/lang/driver/src/backends/aarch64.rs
@@ -15,7 +15,7 @@ use crate::{
 impl Driver {
     pub fn print_aarch64(&mut self, path: &PathBuf, mode: PrintMode) -> Result<(), DriverError> {
         let linearized = self.linearized(path)?;
-        let code = compile(linearized, &axcut2aarch64::Backend);
+        let code = compile::<axcut2aarch64::Backend, _, _, _>(linearized);
 
         Paths::create_aarch64_assembly_dir();
 

--- a/lang/driver/src/backends/rv64.rs
+++ b/lang/driver/src/backends/rv64.rs
@@ -9,7 +9,7 @@ use crate::{paths::Paths, result::DriverError, Driver, PrintMode};
 impl Driver {
     pub fn print_rv_64(&mut self, path: &PathBuf, _mode: PrintMode) -> Result<(), DriverError> {
         let linearized = self.linearized(path)?;
-        let code = compile(linearized, &axcut2rv64::Backend);
+        let code = compile::<axcut2rv64::Backend, _, _, _>(linearized);
         let code_str = axcut2rv64::into_routine::into_rv64_routine(code).to_string();
 
         Paths::create_risc_v_assembly_dir();

--- a/lang/driver/src/backends/x86_64.rs
+++ b/lang/driver/src/backends/x86_64.rs
@@ -15,7 +15,7 @@ use crate::{
 impl Driver {
     pub fn print_x86_64(&mut self, path: &PathBuf, mode: PrintMode) -> Result<(), DriverError> {
         let linearized = self.linearized(path)?;
-        let code = compile(linearized, &axcut2x86_64::Backend);
+        let code = compile::<axcut2x86_64::Backend, _, _, _>(linearized);
         Paths::create_x86_64_assembly_dir();
 
         let mut filename = PathBuf::from(path.file_name().unwrap());


### PR DESCRIPTION
This just removes the unnecessary `self` parameters in the methods of the traits for the backends. This allows to remove the `Backend` arguments from several functions, but in turn makes some type annotations necessary.