### PR TITLE
Add --open function to texify

### DIFF
--- a/app/src/cli/texify.rs
+++ b/app/src/cli/texify.rs
@@ -32,16 +32,23 @@ impl fmt::Display for FontSize {
 
 #[derive(clap::Args)]
 pub struct Args {
+    /// The example to convert to latex
     #[clap(value_parser, value_name = "FILE")]
     filepath: PathBuf,
     /// Which backend to use
     backend: Backend,
+    /// Width that the prettyprinter uses to layout code
     #[clap(long, default_value_t = 80)]
     width: usize,
+    /// Which fontsize to use for generated snippets
     #[clap(long, default_value_t=FontSize::Scriptsize)]
     fontsize: FontSize,
+    /// How many spaces of indentation to use
     #[clap(long, default_value_t = 4)]
     indent: isize,
+    /// Open the generated pdf with the system viewer
+    #[clap(long)]
+    open: bool,
 }
 
 pub fn exec(cmd: Args) -> miette::Result<()> {
@@ -68,6 +75,10 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
             let _ = drv.print_x86_64(&cmd.filepath, driver::PrintMode::Latex);
             let _ = drv.print_latex_all(&cmd.filepath, &Arch::X86_64);
         }
+    }
+
+    if cmd.open {
+        let _ = drv.open_pdf(&cmd.filepath);
     }
 
     Ok(())

--- a/lang/driver/Cargo.toml
+++ b/lang/driver/Cargo.toml
@@ -17,3 +17,4 @@ printer = { path = "../printer" }
 
 thiserror = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
+opener = { version = "0.7.2" }

--- a/lang/driver/src/lib.rs
+++ b/lang/driver/src/lib.rs
@@ -347,6 +347,13 @@ impl Driver {
         Ok(())
     }
 
+    pub fn open_pdf(&mut self, path: &Path) -> Result<(), DriverError> {
+        let filename = path.file_stem().unwrap();
+        let filepath = append_to_path(&Paths::pdf_dir().join(filename), "All.pdf");
+        let _ = opener::open(filepath);
+        Ok(())
+    }
+
     /// Convert a DriverError to a miette report
     pub fn error_to_report(&mut self, err: DriverError, path: &PathBuf) -> miette::Report {
         let content = self.source(path).expect("Couldn't find source file");


### PR DESCRIPTION
Allows to open the generated pdf file directly in the system viewer.
E.g.
```console
> grokking texify examples/Lists.sc aarch64 --open
```