### PR TITLE
Adds exit success or exit failure return to endtoend test 

### DIFF
--- a/testsuite/endtoend/src/errors.rs
+++ b/testsuite/endtoend/src/errors.rs
@@ -19,6 +19,9 @@ pub enum Error {
         tried: String,
         msg: String,
     },
+    TestFailure {
+        num_fail: usize,
+    },
 }
 
 impl Error {
@@ -65,6 +68,7 @@ impl fmt::Display for Error {
             Error::WorkingDir { tried, msg } => {
                 write!(f, "Could not {tried} working dir:\n\t{msg}")
             }
+            Error::TestFailure { num_fail } => write!(f, "{num_fail} tests have failed"),
         }
     }
 }

--- a/testsuite/endtoend/src/examples.rs
+++ b/testsuite/endtoend/src/examples.rs
@@ -1,3 +1,4 @@
+use super::errors::Error;
 use std::{fmt, path::PathBuf};
 
 #[derive(Clone)]
@@ -60,7 +61,7 @@ impl ExampleResult {
         }
     }
 
-    pub fn report(results: Vec<ExampleResult>) {
+    pub fn report(results: Vec<ExampleResult>) -> Result<(), Error> {
         println!("Ran {} tests", results.len());
         let mut num_success = 0;
         let mut num_fail = 0;
@@ -75,7 +76,12 @@ impl ExampleResult {
         println!(
             "\ntest result: {} passed; {} failed\n",
             num_success, num_fail
-        )
+        );
+        if num_fail == 0 {
+            Ok(())
+        } else {
+            Err(Error::TestFailure { num_fail })
+        }
     }
 }
 

--- a/testsuite/endtoend/src/main.rs
+++ b/testsuite/endtoend/src/main.rs
@@ -21,10 +21,9 @@ fn main() -> Result<(), Error> {
     let examples = load_all()?;
     println!("Running fun tests");
     let fun_results = fun_tests::run_tests(&examples);
-    ExampleResult::report(fun_results);
+    ExampleResult::report(fun_results)?;
 
     println!("Running compile tests");
     let compile_results = compile_examples::run_tests(&examples.examples);
-    ExampleResult::report(compile_results);
-    Ok(())
+    ExampleResult::report(compile_results)
 }


### PR DESCRIPTION
Instead of simply reporting, ``ExampleResult` now returns an error when at least one test fails (all testts are still run).
According to the documentation (and my own quick testting), `main` returning `Err` is equivalent to `std::process::exit(1)` (while returning `Ok` is equivalent to `std::process::exit(1)`) which is also equivalent to  `std::process::ExitCode::FAILURE.exit_process()` (this is a nightly feature however)
The only difference here is that Err also prints `Debug` of the reported error to `stderr` while the other two options do not.

If we do not want the stderr output we should probably use `std::process::exit` instead, but otherwise `Result<..>` from `main` seems easier, since then we can easily return early if there are any errors loading the examples