### PR TITLE
Use DriverError for missing binaries

### DIFF
--- a/app/src/cli/texify.rs
+++ b/app/src/cli/texify.rs
@@ -60,25 +60,25 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
     };
 
     let mut drv = Driver::new();
-    let _ = drv.print_compiled(&cmd.filepath, driver::PrintMode::Latex);
-    let _ = drv.print_focused(&cmd.filepath, driver::PrintMode::Latex);
-    let _ = drv.print_linearized(&cmd.filepath, driver::PrintMode::Latex);
-    let _ = drv.print_shrunk(&cmd.filepath, driver::PrintMode::Latex);
-    let _ = drv.print_parsed_tex(&cmd.filepath, &cfg, format!("{}", cmd.fontsize));
+    drv.print_compiled(&cmd.filepath, driver::PrintMode::Latex)?;
+    drv.print_focused(&cmd.filepath, driver::PrintMode::Latex)?;
+    drv.print_linearized(&cmd.filepath, driver::PrintMode::Latex)?;
+    drv.print_shrunk(&cmd.filepath, driver::PrintMode::Latex)?;
+    drv.print_parsed_tex(&cmd.filepath, &cfg, format!("{}", cmd.fontsize))?;
     match cmd.backend {
         Backend::Aarch64 => {
-            let _ = drv.print_aarch64(&cmd.filepath, driver::PrintMode::Latex);
-            let _ = drv.print_latex_all(&cmd.filepath, &Arch::AARCH64);
+            drv.print_aarch64(&cmd.filepath, driver::PrintMode::Latex)?;
+            drv.print_latex_all(&cmd.filepath, &Arch::AARCH64)?;
         }
         Backend::Rv64 => {}
         Backend::X86_64 => {
-            let _ = drv.print_x86_64(&cmd.filepath, driver::PrintMode::Latex);
-            let _ = drv.print_latex_all(&cmd.filepath, &Arch::X86_64);
+            drv.print_x86_64(&cmd.filepath, driver::PrintMode::Latex)?;
+            drv.print_latex_all(&cmd.filepath, &Arch::X86_64)?;
         }
     }
 
     if cmd.open {
-        let _ = drv.open_pdf(&cmd.filepath);
+        drv.open_pdf(&cmd.filepath)?;
     }
 
     Ok(())

--- a/lang/driver/src/backends/aarch64.rs
+++ b/lang/driver/src/backends/aarch64.rs
@@ -71,7 +71,9 @@ impl Driver {
             .args(["-o", dist_path.to_str().unwrap()])
             .arg(source_path)
             .status()
-            .expect("failed to execute as");
+            .map_err(|_| DriverError::BinaryNotFound {
+                bin_name: "as".to_string(),
+            })?;
 
         Paths::create_aarch64_binary_dir();
 
@@ -90,7 +92,9 @@ impl Driver {
             .arg(infra_path.to_str().unwrap())
             .arg(dist_path)
             .status()
-            .expect("Failed to execute gcc");
+            .map_err(|_| DriverError::BinaryNotFound {
+                bin_name: "gcc".to_string(),
+            })?;
 
         Ok(())
     }

--- a/lang/driver/src/backends/x86_64.rs
+++ b/lang/driver/src/backends/x86_64.rs
@@ -70,7 +70,9 @@ impl Driver {
             .args(["-o", dist_path.to_str().unwrap()])
             .arg(source_path)
             .status()
-            .expect("Failed to execute nasm");
+            .map_err(|_| DriverError::BinaryNotFound {
+                bin_name: "nasm".to_string(),
+            })?;
 
         Paths::create_x86_64_binary_dir();
 
@@ -90,7 +92,9 @@ impl Driver {
             .arg(infra_path.to_str().unwrap())
             .arg(dist_path)
             .status()
-            .expect("Failed to execute gcc");
+            .map_err(|_| DriverError::BinaryNotFound {
+                bin_name: "gcc".to_string(),
+            })?;
         Ok(())
     }
 }

--- a/lang/driver/src/lib.rs
+++ b/lang/driver/src/lib.rs
@@ -342,7 +342,9 @@ impl Driver {
             .current_dir(Paths::pdf_dir())
             .arg(filepath.file_name().unwrap())
             .status()
-            .expect("Failed to execute pdflatex");
+            .map_err(|_| DriverError::BinaryNotFound {
+                bin_name: "pdflatex".to_string(),
+            })?;
 
         Ok(())
     }

--- a/lang/driver/src/result.rs
+++ b/lang/driver/src/result.rs
@@ -10,4 +10,7 @@ pub enum DriverError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     TypeError(#[from] fun::typing::errors::Error),
+    #[error("Unable to find binary {bin_name}")]
+    #[diagnostic(code("D-001"))]
+    BinaryNotFound { bin_name: String },
 }


### PR DESCRIPTION
This improves the error message if a binary is not found during execution:

```console
 grokking texify examples/Tuples.sc aarch64

Error: D-001

  × Unable to find binary pdflatex

```