### PR TITLE
Add ELF note indicating non-executable stack

### DIFF
--- a/lang/axcut2x86_64/src/code.rs
+++ b/lang/axcut2x86_64/src/code.rs
@@ -70,6 +70,7 @@ pub enum Code {
     POP(Register),
     RET,
     LAB(String),
+    NOEXECSTACK,
     TEXT,
     GLOBAL(String),
     COMMENT(String),
@@ -376,7 +377,8 @@ impl Print for Code {
                 .append(r.print(cfg, alloc)),
             RET => alloc.text(INDENT).append(alloc.keyword("ret")),
             LAB(l) => alloc.hardline().append(l).append(COLON),
-            TEXT => alloc.keyword("segment .text"),
+            NOEXECSTACK => alloc.keyword("section .note.GNU-stack noalloc noexec nowrite progbits"),
+            TEXT => alloc.keyword("section .text"),
             GLOBAL(l) => alloc.keyword("global").append(alloc.space()).append(l),
             COMMENT(msg) => alloc
                 .text(INDENT)

--- a/lang/axcut2x86_64/src/into_routine.rs
+++ b/lang/axcut2x86_64/src/into_routine.rs
@@ -12,6 +12,7 @@ use axcut2backend::{coder::AssemblyProg, config::TemporaryNumber::Fst};
 pub fn preamble() -> Vec<Code> {
     use Code::*;
     vec![
+        NOEXECSTACK,
         TEXT,
         GLOBAL("asm_main0".to_string()),
         GLOBAL("_asm_main0".to_string()),

--- a/lang/axcut2x86_64/tests/asm/arith.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/arith.x86_64.asm
@@ -1,5 +1,6 @@
     ; asmsyntax=nasm
-segment .text
+section .note.GNU-stack noalloc noexec nowrite progbits
+section .text
 global asm_main0
 global _asm_main0
 global asm_main1

--- a/lang/axcut2x86_64/tests/asm/closure.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/closure.x86_64.asm
@@ -1,5 +1,6 @@
     ; asmsyntax=nasm
-segment .text
+section .note.GNU-stack noalloc noexec nowrite progbits
+section .text
 global asm_main0
 global _asm_main0
 global asm_main1

--- a/lang/axcut2x86_64/tests/asm/either.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/either.x86_64.asm
@@ -1,5 +1,6 @@
     ; asmsyntax=nasm
-segment .text
+section .note.GNU-stack noalloc noexec nowrite progbits
+section .text
 global asm_main0
 global _asm_main0
 global asm_main1

--- a/lang/axcut2x86_64/tests/asm/list.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/list.x86_64.asm
@@ -1,5 +1,6 @@
     ; asmsyntax=nasm
-segment .text
+section .note.GNU-stack noalloc noexec nowrite progbits
+section .text
 global asm_main0
 global _asm_main0
 global asm_main1

--- a/lang/axcut2x86_64/tests/asm/midi.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/midi.x86_64.asm
@@ -1,5 +1,6 @@
     ; asmsyntax=nasm
-segment .text
+section .note.GNU-stack noalloc noexec nowrite progbits
+section .text
 global asm_main0
 global _asm_main0
 global asm_main1

--- a/lang/axcut2x86_64/tests/asm/mini.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/mini.x86_64.asm
@@ -1,5 +1,6 @@
     ; asmsyntax=nasm
-segment .text
+section .note.GNU-stack noalloc noexec nowrite progbits
+section .text
 global asm_main0
 global _asm_main0
 global asm_main1

--- a/lang/axcut2x86_64/tests/asm/nonLinear.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/nonLinear.x86_64.asm
@@ -1,5 +1,6 @@
     ; asmsyntax=nasm
-segment .text
+section .note.GNU-stack noalloc noexec nowrite progbits
+section .text
 global asm_main0
 global _asm_main0
 global asm_main1

--- a/lang/axcut2x86_64/tests/asm/quad.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/quad.x86_64.asm
@@ -1,5 +1,6 @@
     ; asmsyntax=nasm
-segment .text
+section .note.GNU-stack noalloc noexec nowrite progbits
+section .text
 global asm_main0
 global _asm_main0
 global asm_main1


### PR DESCRIPTION
This seems to be necessary on some platforms to ensure that the stack is not executable. On my machine, there are no complaints, but the GitHub-runner always issues a warning.