### PR TITLE
Simplify focusing state

### DIFF
--- a/lang/core2axcut/src/statement/cut.rs
+++ b/lang/core2axcut/src/statement/cut.rs
@@ -1,6 +1,6 @@
 use core_lang::syntax::{
     declaration::{cont_int, lookup_type_declaration},
-    fresh_var,
+    fresh_name, fresh_var,
     statement::{FsCut, FsStatement},
     term::*,
     Name, Ty, Var,
@@ -100,7 +100,7 @@ fn shrink_unknown_cuts(
                         .bindings
                         .into_iter()
                         .map(|binding| axcut::syntax::ContextBinding {
-                            var: fresh_var(state.used_vars, &binding.var),
+                            var: fresh_name(state.used_vars, &binding.var),
                             ..binding
                         })
                         .collect::<Vec<_>>()
@@ -205,7 +205,7 @@ fn shrink_critical_pairs(
                         .bindings
                         .into_iter()
                         .map(|binding| axcut::syntax::ContextBinding {
-                            var: fresh_var(state.used_vars, &binding.var),
+                            var: fresh_name(state.used_vars, &binding.var),
                             ..binding
                         })
                         .collect::<Vec<_>>()
@@ -257,7 +257,7 @@ fn shrink_literal_var(
     var: Var,
     used_vars: &mut HashSet<Var>,
 ) -> axcut::syntax::Statement {
-    let fresh_var = fresh_var(used_vars, "x");
+    let fresh_var = fresh_var(used_vars);
     axcut::syntax::Statement::Literal(axcut::syntax::statements::Literal {
         lit,
         var: fresh_var.clone(),

--- a/lang/core2axcut/src/statement/op.rs
+++ b/lang/core2axcut/src/statement/op.rs
@@ -43,7 +43,7 @@ impl Shrinking for FsOp {
                 var,
                 ty: _,
             }) => {
-                let fresh_var = fresh_var(state.used_vars, "x");
+                let fresh_var = fresh_var(state.used_vars);
                 axcut::syntax::Statement::Op(axcut::syntax::statements::Op {
                     fst: self.fst,
                     op: translate_binop(&self.op),

--- a/lang/core_lang/src/syntax/context.rs
+++ b/lang/core_lang/src/syntax/context.rs
@@ -107,7 +107,6 @@ impl TypingContext {
 
 impl SubstVar for ContextBinding {
     type Target = ContextBinding;
-
     fn subst_sim(self, subst: &[(Var, Var)]) -> ContextBinding {
         match self {
             ContextBinding::VarBinding { var, ty } => ContextBinding::VarBinding {

--- a/lang/core_lang/src/syntax/def.rs
+++ b/lang/core_lang/src/syntax/def.rs
@@ -44,14 +44,13 @@ impl Print for Def {
     }
 }
 
-impl Focusing for Def {
-    type Target = FsDef;
-    fn focus(self, state: &mut FocusingState) -> FsDef {
+impl Def {
+    pub fn focus(mut self) -> FsDef {
         FsDef {
             name: self.name,
             context: self.context,
-            body: self.body.focus(state),
-            used_vars: state.used_vars.clone(),
+            body: self.body.focus(&mut self.used_vars),
+            used_vars: self.used_vars,
         }
     }
 }

--- a/lang/core_lang/src/syntax/mod.rs
+++ b/lang/core_lang/src/syntax/mod.rs
@@ -15,7 +15,7 @@ pub use context::{
 };
 pub use declaration::{Codata, CodataDeclaration, CtorSig, Data, DataDeclaration, DtorSig};
 pub use def::{Def, FsDef};
-pub use names::{fresh_var, Covar, Name, Var};
+pub use names::{fresh_covar, fresh_name, fresh_var, Covar, Name, Var};
 pub use program::Prog;
 pub use statement::BinOp;
 pub use statement::{FsStatement, Statement};

--- a/lang/core_lang/src/syntax/names.rs
+++ b/lang/core_lang/src/syntax/names.rs
@@ -7,20 +7,29 @@ pub type Covar = String;
 pub type Name = String;
 
 #[must_use]
-pub fn fresh_var(used_vars: &mut HashSet<Var>, base_name: &str) -> Var {
+pub fn fresh_name(used_names: &mut HashSet<Name>, base_name: &str) -> Name {
     let mut n = 0;
-    let mut new_var: Var = format!("{base_name}{n}");
-    while used_vars.contains(&new_var) {
+    let mut new_name: Name = format!("{base_name}{n}");
+    while used_names.contains(&new_name) {
         n += 1;
-        new_var = format!("{base_name}{n}");
+        new_name = format!("{base_name}{n}");
     }
-    used_vars.insert(new_var.clone());
-    new_var
+    used_names.insert(new_name.clone());
+    new_name
+}
+
+#[must_use]
+pub fn fresh_var(used_vars: &mut HashSet<Var>) -> Var {
+    fresh_name(used_vars, "x")
+}
+
+#[must_use]
+pub fn fresh_covar(used_covars: &mut HashSet<Covar>) -> Covar {
+    fresh_name(used_covars, "a")
 }
 
 impl SubstVar for Var {
     type Target = Var;
-
     fn subst_sim(self, subst: &[(Var, Var)]) -> Var {
         match subst.iter().find(|(old, _)| *old == self) {
             None => self,

--- a/lang/core_lang/src/syntax/program.rs
+++ b/lang/core_lang/src/syntax/program.rs
@@ -47,8 +47,6 @@ impl<T: Print> Print for XProg<T> {
 
 #[must_use]
 pub fn transform_prog(prog: Prog) -> FsProg {
-    let mut state = FocusingState::default();
-
     FsProg {
         defs: prog
             .defs
@@ -57,8 +55,7 @@ pub fn transform_prog(prog: Prog) -> FsProg {
                 def.body = def
                     .body
                     .uniquify(&mut def.context.vars(), &mut def.used_vars);
-                state.used_vars = def.used_vars.clone();
-                def.focus(&mut state)
+                def.focus()
             })
             .collect(),
         data_types: prog.data_types,

--- a/lang/core_lang/src/syntax/statement/fun.rs
+++ b/lang/core_lang/src/syntax/statement/fun.rs
@@ -71,17 +71,17 @@ impl Uniquify for Fun {
 impl Focusing for Fun {
     type Target = FsStatement;
     ///N(f(t_i)) = bind(t_i)[λas.f(as)]
-    fn focus(self, state: &mut FocusingState) -> FsStatement {
+    fn focus(self, used_vars: &mut HashSet<Var>) -> FsStatement {
         bind_many(
             self.args.into(),
-            Box::new(|args, _: &mut FocusingState| {
+            Box::new(|args, _: &mut HashSet<Var>| {
                 FsCall {
                     name: self.name,
                     args: args.into_iter().collect(),
                 }
                 .into()
             }),
-            state,
+            used_vars,
         )
     }
 }
@@ -113,7 +113,6 @@ impl From<FsCall> for FsStatement {
 
 impl SubstVar for FsCall {
     type Target = FsCall;
-
     fn subst_sim(self, subst: &[(Var, Var)]) -> FsCall {
         FsCall {
             name: self.name,

--- a/lang/core_lang/src/syntax/statement/ifz.rs
+++ b/lang/core_lang/src/syntax/statement/ifz.rs
@@ -104,17 +104,17 @@ impl Uniquify for IfZ {
 impl Focusing for IfZ {
     type Target = FsStatement;
     ///N(ifz(p, s_1, s_2)) = bind(p)[λa.ifz(a, N(s_1), N(s_2))]
-    fn focus(self, state: &mut FocusingState) -> FsStatement {
-        let cont = Box::new(|var, state: &mut FocusingState| {
+    fn focus(self, used_vars: &mut HashSet<Var>) -> FsStatement {
+        let cont = Box::new(|var, used_vars: &mut HashSet<Var>| {
             FsIfZ {
                 ifc: var,
-                thenc: self.thenc.focus(state),
-                elsec: self.elsec.focus(state),
+                thenc: self.thenc.focus(used_vars),
+                elsec: self.elsec.focus(used_vars),
             }
             .into()
         });
 
-        Rc::unwrap_or_clone(self.ifc).bind(cont, state)
+        Rc::unwrap_or_clone(self.ifc).bind(cont, used_vars)
     }
 }
 
@@ -154,7 +154,6 @@ impl From<FsIfZ> for FsStatement {
 
 impl SubstVar for FsIfZ {
     type Target = FsIfZ;
-
     fn subst_sim(self, subst: &[(Var, Var)]) -> FsIfZ {
         FsIfZ {
             ifc: self.ifc.subst_sim(subst),

--- a/lang/core_lang/src/syntax/statement/mod.rs
+++ b/lang/core_lang/src/syntax/statement/mod.rs
@@ -135,13 +135,13 @@ impl Uniquify for Statement {
 
 impl Focusing for Statement {
     type Target = FsStatement;
-    fn focus(self: Statement, state: &mut FocusingState) -> FsStatement {
+    fn focus(self: Statement, used_vars: &mut HashSet<Var>) -> FsStatement {
         match self {
-            Statement::Cut(cut) => cut.focus(state),
-            Statement::Op(op) => op.focus(state),
-            Statement::IfC(ifc) => ifc.focus(state),
-            Statement::IfZ(ifz) => ifz.focus(state),
-            Statement::Fun(call) => call.focus(state),
+            Statement::Cut(cut) => cut.focus(used_vars),
+            Statement::Op(op) => op.focus(used_vars),
+            Statement::IfC(ifc) => ifc.focus(used_vars),
+            Statement::IfZ(ifz) => ifz.focus(used_vars),
+            Statement::Fun(call) => call.focus(used_vars),
             Statement::Done(_) => FsStatement::Done(),
         }
     }

--- a/lang/core_lang/src/syntax/substitution.rs
+++ b/lang/core_lang/src/syntax/substitution.rs
@@ -125,16 +125,16 @@ impl Uniquify for SubstitutionBinding {
 
 impl Focusing for SubstitutionBinding {
     type Target = SubstitutionBinding;
-    fn focus(self, _state: &mut FocusingState) -> Self::Target {
+    fn focus(self, _: &mut HashSet<Var>) -> Self::Target {
         panic!("Focusing should never be called directly on a substitution binding");
     }
 }
 
 impl Bind for SubstitutionBinding {
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> FsStatement {
+    fn bind(self, k: Continuation, used_vars: &mut HashSet<Var>) -> FsStatement {
         match self {
-            SubstitutionBinding::ProducerBinding(prd) => prd.bind(k, state),
-            SubstitutionBinding::ConsumerBinding(cns) => cns.bind(k, state),
+            SubstitutionBinding::ProducerBinding(prd) => prd.bind(k, used_vars),
+            SubstitutionBinding::ConsumerBinding(cns) => cns.bind(k, used_vars),
         }
     }
 }

--- a/lang/core_lang/src/syntax/term/literal.rs
+++ b/lang/core_lang/src/syntax/term/literal.rs
@@ -2,9 +2,11 @@ use printer::{DocAllocator, Print};
 
 use super::{Cns, FsTerm, Mu, Prd, Term};
 use crate::{
-    syntax::{statement::FsCut, types::Ty, Covar, FsStatement, Var},
+    syntax::{fresh_var, statement::FsCut, types::Ty, Covar, FsStatement, Var},
     traits::*,
 };
+
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Literal {
@@ -59,11 +61,11 @@ impl Subst for Literal {
 
 impl Bind for Literal {
     ///bind(⌜n⌝)[k] = ⟨⌜n⌝ | ~μx.k(x)⟩
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> FsStatement {
-        let new_var = state.fresh_var();
+    fn bind(self, k: Continuation, used_vars: &mut HashSet<Var>) -> FsStatement {
+        let new_var = fresh_var(used_vars);
         FsCut::new(
             self,
-            Mu::tilde_mu(&new_var, k(new_var.clone(), state), Ty::I64),
+            Mu::tilde_mu(&new_var, k(new_var.clone(), used_vars), Ty::I64),
             Ty::I64,
         )
         .into()
@@ -72,7 +74,6 @@ impl Bind for Literal {
 
 #[cfg(test)]
 mod lit_tests {
-
     use super::Bind;
     use super::{Literal, Subst};
     use crate::{

--- a/lang/core_lang/src/syntax/term/mod.rs
+++ b/lang/core_lang/src/syntax/term/mod.rs
@@ -128,50 +128,48 @@ impl<T: PrdCns> Uniquify for Term<T> {
 
 impl Focusing for Term<Prd> {
     type Target = FsTerm<Prd>;
-
-    fn focus(self, st: &mut FocusingState) -> Self::Target {
+    fn focus(self, used_vars: &mut HashSet<Var>) -> Self::Target {
         match self {
             Term::XVar(var) => var.into(),
             Term::Literal(lit) => lit.into(),
-            Term::Mu(mu) => mu.focus(st).into(),
-            Term::Xtor(xtor) => xtor.focus(st),
-            Term::XCase(xcase) => xcase.focus(st).into(),
+            Term::Mu(mu) => mu.focus(used_vars).into(),
+            Term::Xtor(xtor) => xtor.focus(used_vars),
+            Term::XCase(xcase) => xcase.focus(used_vars).into(),
         }
     }
 }
 impl Focusing for Term<Cns> {
     type Target = FsTerm<Cns>;
-
-    fn focus(self, st: &mut FocusingState) -> Self::Target {
+    fn focus(self, used_vars: &mut HashSet<Var>) -> Self::Target {
         match self {
             Term::XVar(covar) => covar.into(),
             Term::Literal(_) => panic!("Cannot happen"),
-            Term::Mu(mu) => mu.focus(st).into(),
-            Term::Xtor(xtor) => xtor.focus(st),
-            Term::XCase(xcase) => xcase.focus(st).into(),
+            Term::Mu(mu) => mu.focus(used_vars).into(),
+            Term::Xtor(xtor) => xtor.focus(used_vars),
+            Term::XCase(xcase) => xcase.focus(used_vars).into(),
         }
     }
 }
 
 impl Bind for Term<Prd> {
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> FsStatement {
+    fn bind(self, k: Continuation, used_vars: &mut HashSet<Var>) -> FsStatement {
         match self {
-            Term::XVar(var) => var.bind(k, state),
-            Term::Literal(lit) => lit.bind(k, state),
-            Term::Mu(mu) => mu.bind(k, state),
-            Term::Xtor(xtor) => xtor.bind(k, state),
-            Term::XCase(xcase) => xcase.bind(k, state),
+            Term::XVar(var) => var.bind(k, used_vars),
+            Term::Literal(lit) => lit.bind(k, used_vars),
+            Term::Mu(mu) => mu.bind(k, used_vars),
+            Term::Xtor(xtor) => xtor.bind(k, used_vars),
+            Term::XCase(xcase) => xcase.bind(k, used_vars),
         }
     }
 }
 impl Bind for Term<Cns> {
-    fn bind(self, k: Continuation, state: &mut FocusingState) -> FsStatement {
+    fn bind(self, k: Continuation, used_vars: &mut HashSet<Var>) -> FsStatement {
         match self {
-            Term::XVar(covar) => covar.bind(k, state),
-            Term::Literal(lit) => lit.bind(k, state),
-            Term::Mu(mu) => mu.bind(k, state),
-            Term::Xtor(xtor) => xtor.bind(k, state),
-            Term::XCase(xcase) => xcase.bind(k, state),
+            Term::XVar(covar) => covar.bind(k, used_vars),
+            Term::Literal(lit) => lit.bind(k, used_vars),
+            Term::Mu(mu) => mu.bind(k, used_vars),
+            Term::Xtor(xtor) => xtor.bind(k, used_vars),
+            Term::XCase(xcase) => xcase.bind(k, used_vars),
         }
     }
 }

--- a/lang/core_lang/src/syntax/term/xvar.rs
+++ b/lang/core_lang/src/syntax/term/xvar.rs
@@ -6,6 +6,8 @@ use crate::{
     traits::*,
 };
 
+use std::collections::HashSet;
+
 /// Either a variable or a covariable:
 /// - A variable if `T = Prd`
 /// - A covariable if `T = Cns`
@@ -108,15 +110,14 @@ impl<T: PrdCns> Bind for XVar<T> {
     fn bind(
         self,
         k: Continuation,
-        state: &mut FocusingState,
+        used_var: &mut HashSet<Var>,
     ) -> crate::syntax::statement::FsStatement {
-        k(self.var, state)
+        k(self.var, used_var)
     }
 }
 
 impl<T: PrdCns> SubstVar for XVar<T> {
     type Target = XVar<T>;
-
     fn subst_sim(mut self, subst: &[(Var, Var)]) -> XVar<T> {
         match subst.iter().find(|(old, _)| *old == self.var) {
             None => self,

--- a/lang/core_lang/src/traits/mod.rs
+++ b/lang/core_lang/src/traits/mod.rs
@@ -3,7 +3,7 @@ mod substitution;
 mod typed;
 mod uniquify;
 
-pub use focus::{bind_many, Bind, Continuation, Focusing, FocusingState};
+pub use focus::{bind_many, Bind, Continuation, Focusing};
 pub use substitution::{Subst, SubstVar};
 pub use typed::Typed;
 pub use uniquify::Uniquify;

--- a/lang/fun2core/src/definition.rs
+++ b/lang/fun2core/src/definition.rs
@@ -1,5 +1,5 @@
 use core_lang::syntax::{
-    fresh_var,
+    fresh_covar, fresh_var,
     term::{Cns, Prd},
     CodataDeclaration, Ty,
 };
@@ -15,11 +15,11 @@ pub struct CompileState<'a> {
 
 impl CompileState<'_> {
     pub fn fresh_var(&mut self) -> Variable {
-        fresh_var(&mut self.used_vars, "x")
+        fresh_var(&mut self.used_vars)
     }
 
     pub fn fresh_covar(&mut self) -> Covariable {
-        fresh_var(&mut self.used_vars, "a")
+        fresh_covar(&mut self.used_vars)
     }
 }
 

--- a/lang/fun2core/src/program.rs
+++ b/lang/fun2core/src/program.rs
@@ -1,7 +1,7 @@
 //! Compiling a well-typed program from the source language `Fun` to the intermediate language `Core`.
 
 use crate::definition::{CompileState, CompileWithCont};
-use core_lang::syntax::{fresh_var, term::Cns, CodataDeclaration, Context};
+use core_lang::syntax::{fresh_covar, term::Cns, CodataDeclaration, Context};
 use fun::syntax::types::OptTyped;
 use fun::traits::UsedBinders;
 
@@ -172,7 +172,7 @@ pub fn compile_dtor(
 ) -> core_lang::syntax::declaration::XtorSig<core_lang::syntax::declaration::Codata> {
     let mut new_args = compile_context(dtor.args);
 
-    let new_covar = fresh_var(&mut new_args.vars().into_iter().collect(), "a");
+    let new_covar = fresh_covar(&mut new_args.vars().into_iter().collect());
 
     new_args
         .bindings


### PR DESCRIPTION
As the focusing state merely consists of the used binders and since the methods on it in the `impl` block are either not needed anymore are can be defined more as functions which are used in other places as well, there is no need for the focusing state to be a struct. This also simplifies some threading of `used_vars` when focusing. Most of the changes here are trivial renamings.