### PR TITLE
Remove annotations in clauses

### DIFF
--- a/benchmarks/suite/IterateIncrement/IterateIncrement.sc
+++ b/benchmarks/suite/IterateIncrement/IterateIncrement.sc
@@ -2,5 +2,5 @@ codata Fun[A, B] { Apply(x: A) : B }
 
 def iterate(i: i64, f: Fun[i64,i64], a: i64): i64 { if i == 0 {a} else {iterate(i - 1, f, f.Apply[i64,i64](a))} }
 
-def main(n: i64): i64 { println_i64(iterate(n, cocase { Apply(x: i64) => x + 1}, 0));
+def main(n: i64): i64 { println_i64(iterate(n, cocase { Apply(x) => x + 1}, 0));
                         0 }

--- a/benchmarks/suite/LookupTree/LookupTree.sc
+++ b/benchmarks/suite/LookupTree/LookupTree.sc
@@ -1,9 +1,9 @@
 data Tree[A] { Leaf(x: A), Node(left: Tree[A], right: Tree[A]) }
 
-def create(i: i64, n: i64): Tree[i64] { if i < n {let t: Tree[i64] = create(i + 1, n); Node(t, t) } else {Leaf(n)} }
+def create(i: i64, n: i64): Tree[i64] { if i < n {let t: Tree[i64] = create(i + 1, n); Node(t, t) } else { Leaf(n) } }
 
-def lookup(t: Tree[i64]): i64 { t.case[i64] { Leaf(v: i64) => v,
-                                              Node(left: Tree[i64], right: Tree[i64]) => lookup(left) }}
+def lookup(t: Tree[i64]): i64 { t.case[i64] { Leaf(v) => v,
+                                              Node(left, right) => lookup(left) }}
 
 def main(n: i64): i64 { println_i64(lookup(create(0, n)));
                         0 }

--- a/benchmarks/suite/MatchOptions/MatchOptions.sc
+++ b/benchmarks/suite/MatchOptions/MatchOptions.sc
@@ -1,8 +1,8 @@
 data Option[A] { None, Some(x: A) }
 
 def attempt(i: i64): Option[i64] { if i == 0 { Some(i) } else { attempt(i - 1).case[i64] { None => None,
-                                                                                           Some(x: i64) => Some(x + 1) } } }
+                                                                                           Some(x) => Some(x + 1) } } }
 
 def main(n: i64): i64 { println_i64(attempt(n).case[i64] { None => -1,
-                                                           Some(x: i64) => x });
+                                                           Some(x) => x });
                         0 }

--- a/benchmarks/suite/SumRange/SumRange.sc
+++ b/benchmarks/suite/SumRange/SumRange.sc
@@ -3,7 +3,7 @@ data List[A] { Nil, Cons(x: A, xs: List[A]) }
 def range(i: i64, n: i64): List[i64] { if i < n { Cons(i, range(i + 1, n)) } else { Nil } }
 
 def sum(xs: List[i64]): i64 { xs.case[i64] { Nil => 0,
-                                             Cons(y: i64, ys: List[i64]) => y + sum(ys) } }
+                                             Cons(y, ys) => y + sum(ys) } }
 
 def main(n: i64): i64 { println_i64(sum(range(0, n)));
                         0 }

--- a/examples/FastMultiplication.sc
+++ b/examples/FastMultiplication.sc
@@ -2,7 +2,7 @@ data List[A] { Nil, Cons(x: A, xs: List[A]) }
 
 // Fast multiplication function from the introduction of the paper.
 def fmult(l : List[i64]) : i64 { label a { mult(l,a) } }
-def mult(l : List[i64], a :cns i64) : i64 { l.case[i64] { Nil => println_i64(21); 1,
-                                                          Cons(x :i64 , xs :List[i64]) => println_i64(42); if x == 0 { goto(0; a) } else { x * mult(xs, a) }}}
+def mult(l : List[i64], a:cns i64) : i64 { l.case[i64] { Nil => println_i64(21); 1,
+                                                         Cons(x , xs) => println_i64(42); if x == 0 { goto(0; a) } else { x * mult(xs, a) }}}
 def main() : i64 { println_i64(fmult(Cons(2, Cons(0, Cons(3, Cons(3, Nil))))));
                    0 }

--- a/examples/IterateIncrement.sc
+++ b/examples/IterateIncrement.sc
@@ -2,5 +2,5 @@ codata Fun[A, B] { Apply(x: A) : B }
 
 def iterate(i: i64, f: Fun[i64,i64], a: i64): i64 { if i == 0 {a} else {iterate(i - 1, f, f.Apply[i64,i64](a))} }
 
-def main(n: i64): i64 { println_i64(iterate(n, cocase { Apply(x: i64) => x + 1}, 0));
+def main(n: i64): i64 { println_i64(iterate(n, cocase { Apply(x) => x + 1}, 0));
                         0 }

--- a/examples/Lambdas.sc
+++ b/examples/Lambdas.sc
@@ -1,8 +1,8 @@
 codata Fun[A, B] { Apply(x: A) : B }
 
-def nonValueArguments() : i64 { cocase { Apply(x:i64) => cocase { Apply(y:i64) => y}}.Apply[i64, Fun[i64,i64]](1 + 2).Apply[i64, i64](3 + 4) }
+def nonValueArguments() : i64 { cocase { Apply(x) => cocase { Apply(y) => y}}.Apply[i64, Fun[i64,i64]](1 + 2).Apply[i64, i64](3 + 4) }
 
-def higherOrder() : i64 {  cocase { Apply(x:Fun[i64, i64]) => cocase { Apply(y:i64) => x.Apply[i64, i64](y) }}.Apply[Fun[i64,i64], Fun[i64,i64]](cocase { Apply(z:i64) => 4 + z}).Apply[i64, i64](3 + 1) }
+def higherOrder() : i64 {  cocase { Apply(x) => cocase { Apply(y) => x.Apply[i64, i64](y) }}.Apply[Fun[i64,i64], Fun[i64,i64]](cocase { Apply(z) => 4 + z}).Apply[i64, i64](3 + 1) }
 
 def main() : i64 { println_i64(higherOrder());
                    0 }

--- a/examples/LazyPair.sc
+++ b/examples/LazyPair.sc
@@ -8,7 +8,7 @@ def swapLazy(x:LazyPair[i64,i64]) : LazyPair[i64, i64] { cocase { Fst => x.Snd[i
 def toTuple(x:LazyPair[i64,i64]) : Pair[i64,i64] { Tup(x.Fst[i64, i64], x.Snd[i64, i64]) }
 
 // Convert a strict tuple to a lazy tuple.
-def fromTuple(x:Pair[i64,i64]) : LazyPair[i64,i64] { x.case[i64,i64] { Tup(a:i64, b:i64) => cocase { Fst => a, Snd => b }} }
+def fromTuple(x:Pair[i64,i64]) : LazyPair[i64,i64] { x.case[i64,i64] { Tup(a, b) => cocase { Fst => a, Snd => b }} }
 
 def pairSum(x:LazyPair[i64,i64]) : i64 { (x.Fst[i64, i64]) + (x.Snd[i64, i64]) }
 

--- a/examples/Lists.sc
+++ b/examples/Lists.sc
@@ -3,21 +3,21 @@ codata Fun[A, B] { Apply(x: A) : B }
 
 def map(f : Fun[i64, i64] , l : List[i64]) : List[i64] {
     l.case[i64] { Nil => Nil,
-                  Cons(x : i64, xs : List[i64]) => Cons(f.Apply[i64, i64](x), map(f, xs)) } }
+                  Cons(x, xs) => Cons(f.Apply[i64, i64](x), map(f, xs)) } }
 
 def mult(x : List[i64]) : i64 {
     x.case[i64] { Nil => 1,
-                  Cons(y :i64, ys : List[i64]) => y * mult(ys) } }
+                  Cons(y, ys) => y * mult(ys) } }
 
 codata Fun2[A, B, C] { Apply2(x: A, y: B): C }
 
 def foldr(f : Fun2[i64, i64, i64], st : i64 , l : List[i64]) : i64 {
     l.case[i64] { Nil => st,
-                  Cons(y : i64 , ys : List[i64]) => f.Apply2[i64, i64,i64](y, foldr(f, st, ys)) }}
+                  Cons(y , ys) => f.Apply2[i64, i64,i64](y, foldr(f, st, ys)) }}
 
 def len(l : List[i64]) : i64 {
     l.case[i64] { Nil => 0,
-                  Cons(x:i64,xs:List[i64]) => 1 + len(xs) }}
+                  Cons(x,xs) => 1 + len(xs) }}
 
 def main() : i64  { println_i64(len(Cons(1 + 2, Cons(2, Cons(3, Cons(4, Nil))))));
                     0 }

--- a/examples/LookupTree.sc
+++ b/examples/LookupTree.sc
@@ -1,9 +1,9 @@
 data Tree[A] { Leaf(x: A), Node(left: Tree[A], right: Tree[A]) }
 
-def create(i: i64, n: i64): Tree[i64] { if i < n {let t: Tree[i64] = create(i + 1, n); Node(t, t) } else {Leaf(n)} }
+def create(i: i64, n: i64): Tree[i64] { if i < n {let t: Tree[i64] = create(i + 1, n); Node(t, t) } else { Leaf(n) } }
 
-def lookup(t: Tree[i64]): i64 { t.case[i64] { Leaf(v: i64) => v,
-                                              Node(left: Tree[i64], right: Tree[i64]) => lookup(left) }}
+def lookup(t: Tree[i64]): i64 { t.case[i64] { Leaf(v) => v,
+                                              Node(left, right) => lookup(left) }}
 
 def main(n: i64): i64 { println_i64(lookup(create(0, n)));
                         0 }

--- a/examples/MatchOptions.sc
+++ b/examples/MatchOptions.sc
@@ -1,8 +1,8 @@
 data Option[A] { None, Some(x: A) }
 
 def attempt(i: i64): Option[i64] { if i == 0 { Some(i) } else { attempt(i - 1).case[i64] { None => None,
-                                                                                           Some(x: i64) => Some(x + 1) } } }
+                                                                                           Some(x) => Some(x + 1) } } }
 
 def main(n: i64): i64 { println_i64(attempt(n).case[i64] { None => -1,
-                                                           Some(x: i64) => x });
+                                                           Some(x) => x });
                         0 }

--- a/examples/Stream.sc
+++ b/examples/Stream.sc
@@ -5,7 +5,7 @@ def repeat(x: i64) : Stream[i64] { cocase { Hd => x, Tl => repeat(x) } }
 def const1() : Stream[i64] { cocase { Hd => 1, Tl => const1() } }
 
 def take(n:i64,x:Stream[i64]) : List[i64] { if n == 0 {Nil} else {Cons(x.Hd[i64],take(n-1,x.Tl[i64]))} }
-def sumList(ls:List[i64]) : i64 { ls.case[i64] { Nil=>0, Cons(x:i64, xs:List[i64]) => x+(sumList(xs)) } }
+def sumList(ls:List[i64]) : i64 { ls.case[i64] { Nil=>0, Cons(x, xs) => x+(sumList(xs)) } }
 
 def main() : i64 { println_i64(sumList(take(5,repeat(5))));
                    0 }

--- a/examples/SumRange.sc
+++ b/examples/SumRange.sc
@@ -3,7 +3,7 @@ data List[A] { Nil, Cons(x: A, xs: List[A]) }
 def range(i: i64, n: i64): List[i64] { if i < n { Cons(i, range(i + 1, n)) } else { Nil } }
 
 def sum(xs: List[i64]): i64 { xs.case[i64] { Nil => 0,
-                                             Cons(y: i64, ys: List[i64]) => y + sum(ys) } }
+                                             Cons(y, ys) => y + sum(ys) } }
 
 def main(n: i64): i64 { println_i64(sum(range(0, n)));
                         0 }

--- a/examples/Tuples.sc
+++ b/examples/Tuples.sc
@@ -1,11 +1,11 @@
 data Pair[A, B] { Tup(x:A,y:B) }
 data List[A] { Nil, Cons(x: A, xs: List[A]) }
 
-def swap(x : Pair[i64, i64]) : Pair[i64, i64] { x.case[i64, i64] { Tup(a : i64, b : i64) => Tup(b, a) } }
+def swap(x : Pair[i64, i64]) : Pair[i64, i64] { x.case[i64, i64] { Tup(a, b) => Tup(b, a) } }
 def diag(x : i64) : Pair[i64, i64] { Tup(x, x) }
-def first(x : Pair[i64, i64]) : i64 { x.case[i64, i64] { Tup(a : i64, b : i64) => a } }
-def second(x : Pair[i64, i64]) : i64 { x.case[i64, i64] { Tup(a : i64, b : i64) => b } }
-def toList(x : Pair[i64, i64] ) : List[i64] { x.case[i64, i64] { Tup(a : i64, b : i64) => Cons(a, Cons(b, Nil)) } }
+def first(x : Pair[i64, i64]) : i64 { x.case[i64, i64] { Tup(a, b ) => a } }
+def second(x : Pair[i64, i64]) : i64 { x.case[i64, i64] { Tup(a, b) => b } }
+def toList(x : Pair[i64, i64] ) : List[i64] { x.case[i64, i64] { Tup(a, b) => Cons(a, Cons(b, Nil)) } }
 
 def main() : i64 { println_i64(second(Tup(1, 2)));
                    0 }

--- a/examples/paper_examples.sc
+++ b/examples/paper_examples.sc
@@ -12,25 +12,25 @@ def ex23() : i64 { fac(1) }
 // section 2.4
 data List[A] { Nil, Cons(x: A, xs: List[A]) }
 def sum(x:List[i64]) : i64 { x.case[i64] { Nil => 0,
-                                           Cons(y:i64, ys:List[i64]) => y + sum(ys) }}
+                                           Cons(y, ys) => y + sum(ys) }}
 
 codata Stream[A] { Hd : A, Tl : Stream[A] }
 def repeat(x:i64) : Stream[i64] { cocase { Hd => x, Tl => repeat(x) } }
 
 // section 2.4.1, example 2.4
 data Pair[A, B] { Tup(x:A, y:B) }
-def swap(x:Pair[i64, i64]) : Pair[i64, i64] { x.case[i64, i64] { Tup(y:i64, z:i64) => Tup(z, y) } }
+def swap(x:Pair[i64, i64]) : Pair[i64, i64] { x.case[i64, i64] { Tup(y, z) => Tup(z, y) } }
 
 // section 2.4.2, example 2.5
 codata LazyPair[A, B] { Fst : A, Snd : B }
 def swaplazy(x:LazyPair[i64, i64]) : LazyPair[i64, i64] { cocase { Fst => x.Snd[i64, i64], Snd => x.Fst[i64, i64] } }
 
 // example 2.6
-def ex26() : i64 { cocase { Apply(x:i64) => x * x }.Apply[i64, i64](2) }
+def ex26() : i64 { cocase { Apply(x) => x * x }.Apply[i64, i64](2) }
 
 //example 2.7 def mult(l:List[i64]) : i64 { label a { mult2(l, a) }}
 def mult2(l:List[i64],a:cns i64) : i64 { l.case[i64] { Nil => 1,
-                                                       Cons(x:i64, xs:List[i64]) => if x == 0 {goto(0; a)} else {x * mult2(xs, a)}}}
+                                                       Cons(x, xs) => if x == 0 {goto(0; a)} else {x * mult2(xs, a)}}}
 
 // section 5.1
 def sec51() : i64 { (2 * 3) * 4 }
@@ -40,17 +40,17 @@ def letex() : i64 { let x : i64 = 2; x * x }
 def labelex() : i64 { label a { goto(0; a) } }
 
 //section 5.4
-def casecase() : List[i64] { Nil.case[i64] { Nil => Nil, Cons(x:i64, xs:List[i64]) => xs}.case[i64] {
+def casecase() : List[i64] { Nil.case[i64] { Nil => Nil, Cons(x, xs) => xs}.case[i64] {
                    Nil => Nil,
-                   Cons(y:i64, ys:List[i64]) => ys }}
+                   Cons(y, ys) => ys }}
 
 //section 5.5
 def tltltl() : Stream[i64] { repeat(1).Tl[i64].Tl[i64].Tl[i64] }
 
 //section 5.6
 codata Fun[A, B] { Apply(x: A) : B }
-def criticalEta1(b:cns Fun[i64, i64]) : Fun[i64, i64] { let x : Fun[i64, i64] = cocase { Apply(y:i64) => goto(cocase { Apply(z:i64) => 1 }; b).Apply[i64, i64](y) }; cocase { Apply(z:i64) => 3 }}
-def criticalEta2(b:cns Fun[i64, i64]) : Fun[i64, i64] { let x : Fun[i64, i64] = goto(cocase { Apply(z:i64) => 1 }; b); cocase { Apply(z:i64) => 3 }}
+def criticalEta1(b:cns Fun[i64, i64]) : Fun[i64, i64] { let x : Fun[i64, i64] = cocase { Apply(y) => goto(cocase { Apply(z) => 1 }; b).Apply[i64, i64](y) }; cocase { Apply(z) => 3 }}
+def criticalEta2(b:cns Fun[i64, i64]) : Fun[i64, i64] { let x : Fun[i64, i64] = goto(cocase { Apply(z) => 1 }; b); cocase { Apply(z) => 3 }}
 
 //def main : i64 { println_i64(ex211());
 //                 0 }

--- a/lang/core_lang/src/syntax/context.rs
+++ b/lang/core_lang/src/syntax/context.rs
@@ -1,4 +1,7 @@
-use printer::{tokens::COLON, DocAllocator, Print};
+use printer::{
+    tokens::{CNS, COLON},
+    DocAllocator, Print,
+};
 
 use super::{Covar, Ty, Var};
 use crate::traits::*;
@@ -67,13 +70,14 @@ impl Print for ContextBinding {
         match self {
             ContextBinding::VarBinding { var, ty } => var
                 .print(cfg, alloc)
-                .append(alloc.text(COLON))
+                .append(alloc.space())
+                .append(COLON)
                 .append(alloc.space())
                 .append(ty.print(cfg, alloc)),
             ContextBinding::CovarBinding { covar, ty } => covar
                 .print(cfg, alloc)
                 .append(alloc.space())
-                .append(alloc.text(":cns"))
+                .append(CNS)
                 .append(alloc.space())
                 .append(ty.print(cfg, alloc)),
         }

--- a/lang/fun/src/lib.rs
+++ b/lang/fun/src/lib.rs
@@ -7,7 +7,7 @@ pub mod typing;
 pub mod test_common {
     use super::{
         syntax::{
-            context::{TypeContext, TypingContext},
+            context::{NameContext, TypeContext, TypingContext},
             declarations::{CodataDeclaration, CtorSig, DataDeclaration, Definition, DtorSig},
             terms::{BinOp, Case, Clause, Fun, Lit, Op, PrdCns::Prd, XVar},
             types::{Ty, TypeArgs},
@@ -28,6 +28,13 @@ pub mod test_common {
             ),
         );
         ctx_cons
+    }
+
+    fn context_cons_i64_names() -> NameContext {
+        let mut ctx_cons_names = NameContext::default();
+        ctx_cons_names.bindings.push("x".to_string());
+        ctx_cons_names.bindings.push("xs".to_string());
+        ctx_cons_names
     }
 
     fn context_cons_i64() -> TypingContext {
@@ -391,6 +398,7 @@ pub mod test_common {
                         span: Span::default(),
                         is_clause: true,
                         xtor: "Nil".to_owned(),
+                        context_names: NameContext::default(),
                         context: TypingContext::default(),
                         rhs: Lit::mk(1).into(),
                     },
@@ -398,7 +406,8 @@ pub mod test_common {
                         span: Span::default(),
                         is_clause: true,
                         xtor: "Cons".to_owned(),
-                        context: context_cons_i64(),
+                        context_names: context_cons_i64_names(),
+                        context: TypingContext::default(),
                         rhs: Op {
                             span: Span::default(),
                             fst: Rc::new(XVar::mk("x").into()),
@@ -446,6 +455,7 @@ pub mod test_common {
                         span: Span::default(),
                         is_clause: true,
                         xtor: "Nil".to_owned(),
+                        context_names: NameContext::default(),
                         context: TypingContext::default(),
                         rhs: Lit::mk(1).into(),
                     },
@@ -453,6 +463,7 @@ pub mod test_common {
                         span: Span::default(),
                         is_clause: true,
                         xtor: "Cons".to_owned(),
+                        context_names: context_cons_i64_names(),
                         context: context_cons_i64(),
                         rhs: Op {
                             span: Span::default(),

--- a/lang/fun/src/parser/fun.lalrpop
+++ b/lang/fun/src/parser/fun.lalrpop
@@ -96,6 +96,10 @@ pub OptContext: TypingContext = {
     <l: @L> <bindings: OptParenthesizedList<Binding>> <r: @R> => TypingContext { span: span(l, r), bindings, },
 }
 
+pub OptNameContext: NameContext = {
+    <l: @L> <bindings: OptParenthesizedList<Name>> <r: @R> => NameContext { span: span(l, r), bindings, },
+}
+
 // Types
 //
 //
@@ -235,8 +239,8 @@ Destructor: Destructor = {
 }
 
 Clause: Clause = {
-    <l: @L> <xtor: XtorName> <context: OptContext> "=>" <rhs: Term> <r: @R> =>
-        Clause { span: span(l, r), is_clause: true, xtor, context, rhs, },
+    <l: @L> <xtor: XtorName> <context_names: OptNameContext> "=>" <rhs: Term> <r: @R> =>
+        Clause { span: span(l, r), is_clause: true, xtor, context_names, context: TypingContext::default(), rhs, },
 }
 
 Case: Case = {
@@ -245,8 +249,8 @@ Case: Case = {
 }
 
 Coclause: Clause = {
-    <l: @L> <xtor: XtorName> <context: OptContext> "=>" <rhs: Term> <r: @R> =>
-        Clause { span: span(l, r), is_clause: false, xtor, context, rhs, },
+    <l: @L> <xtor: XtorName> <context_names: OptNameContext> "=>" <rhs: Term> <r: @R> =>
+        Clause { span: span(l, r), is_clause: false, xtor, context_names, context: TypingContext::default(), rhs, },
 }
 
 Cocase: Cocase = {

--- a/lang/fun/src/parser/mod.rs
+++ b/lang/fun/src/parser/mod.rs
@@ -106,7 +106,7 @@ mod parser_tests {
         let result = parser.parse(
             "data List[A] { Nil, Cons(x:A,xs:List[A]) }
             codata Stream[A] { Hd : A , Tl : Stream[A] }
-            def mult(l:List[i64]):i64 { l.case[i64] {Nil => 1, Cons(x:i64, xs:List[i64]) => x*mult(xs)} }",
+            def mult(l:List[i64]):i64 { l.case[i64] {Nil => 1, Cons(x, xs) => x*mult(xs)} }",
         );
         assert_eq!(result, Ok(expected))
     }

--- a/lang/fun/src/syntax/declarations/data_declaration.rs
+++ b/lang/fun/src/syntax/declarations/data_declaration.rs
@@ -112,7 +112,7 @@ mod data_declaration_tests {
     #[test]
     fn display_list() {
         let result = data_list().print_to_string(Default::default());
-        let expected = "data List[A] { Nil, Cons(x: A, xs: List[A]) }";
+        let expected = "data List[A] { Nil, Cons(x : A, xs : List[A]) }";
         assert_eq!(result, expected)
     }
 

--- a/lang/fun/src/syntax/declarations/mod.rs
+++ b/lang/fun/src/syntax/declarations/mod.rs
@@ -288,7 +288,7 @@ mod module_tests {
     fn display_args() {
         assert_eq!(
             example_args().print_to_string(Default::default()),
-            "def f(x: i64, a :cns i64): i64 { 4 }".to_string(),
+            "def f(x : i64, a :cns i64): i64 { 4 }".to_string(),
         )
     }
 

--- a/lang/fun/src/syntax/types.rs
+++ b/lang/fun/src/syntax/types.rs
@@ -36,7 +36,7 @@ pub enum Ty {
 }
 
 fn create_instance(
-    span: &Span,
+    span: Span,
     instance_name: String,
     type_args: &TypeArgs,
     pol: Polarity,
@@ -121,7 +121,7 @@ impl Ty {
                             name: name.clone(),
                         }),
                         Some((pol, type_params, xtors)) => create_instance(
-                            span,
+                            *span,
                             instance_name,
                             type_args,
                             pol.clone(),

--- a/lang/fun/src/typing/check.rs
+++ b/lang/fun/src/typing/check.rs
@@ -63,31 +63,30 @@ pub fn check_args(
                         return Err(Error::ExpectedCovariableGotTerm {
                             span: variable.span.to_miette(),
                         });
-                    } else {
-                        let found_ty =
-                            context.lookup_covar(&variable.var, &variable.span.to_miette())?;
-                        if variable.ty.is_none() {
-                            Ok(())
-                        } else {
-                            check_equality(
-                                &variable.span,
-                                symbol_table,
-                                &variable.ty.unwrap(),
-                                &found_ty,
-                            )
-                        }?;
-
-                        check_equality(&variable.span, symbol_table, ty, &found_ty)?;
-                        new_subst.push(
-                            XVar {
-                                span: variable.span,
-                                var: variable.var,
-                                ty: Some(found_ty),
-                                chi: Some(Cns),
-                            }
-                            .into(),
-                        );
                     }
+                    let found_ty =
+                        context.lookup_covar(&variable.var, &variable.span.to_miette())?;
+                    if variable.ty.is_none() {
+                        Ok(())
+                    } else {
+                        check_equality(
+                            &variable.span,
+                            symbol_table,
+                            &variable.ty.unwrap(),
+                            &found_ty,
+                        )
+                    }?;
+
+                    check_equality(&variable.span, symbol_table, ty, &found_ty)?;
+                    new_subst.push(
+                        XVar {
+                            span: variable.span,
+                            var: variable.var,
+                            ty: Some(found_ty),
+                            chi: Some(Cns),
+                        }
+                        .into(),
+                    );
                 }
                 _ => return Err(Error::ExpectedCovariableGotTerm { span: *span }),
             },

--- a/lang/fun/src/typing/symbol_table.rs
+++ b/lang/fun/src/typing/symbol_table.rs
@@ -199,12 +199,11 @@ impl BuildSymbolTable for Definition {
                 span: self.span.to_miette(),
                 name: self.name.clone(),
             });
-        } else {
-            symbol_table.funs.insert(
-                self.name.clone(),
-                (self.context.clone(), self.ret_ty.clone()),
-            );
         }
+        symbol_table.funs.insert(
+            self.name.clone(),
+            (self.context.clone(), self.ret_ty.clone()),
+        );
         Ok(())
     }
 }

--- a/lang/fun2core/src/terms/case.rs
+++ b/lang/fun2core/src/terms/case.rs
@@ -65,8 +65,7 @@ mod compile_tests {
 
     #[test]
     fn compile_list() {
-        let term =
-            parse_term!("(Cons(1,Nil)).case[i64] { Nil => 0, Cons(x : i64,xs : List[i64]) => x }");
+        let term = parse_term!("(Cons(1,Nil)).case[i64] { Nil => 0, Cons(x,xs) => x }");
         let term_typed = term
             .check(
                 &mut symbol_table_list(),

--- a/testsuite/success/case_of.sc
+++ b/testsuite/success/case_of.sc
@@ -1,5 +1,5 @@
 data List[A] { Nil, Cons(x: A, xs: List[A]) }
 
-def isEmpty(xs: List[i64]): i64 { xs.case[i64] { Nil => 0, Cons(x: i64,xs: List[i64]) => 1 } }
+def isEmpty(xs: List[i64]): i64 { xs.case[i64] { Nil => 0, Cons(x,xs) => 1 } }
 
-def safeHead(xs: List[i64]): i64 { xs.case[i64] { Nil => 0, Cons(y: i64, ys: List[i64]) => y}}
+def safeHead(xs: List[i64]): i64 { xs.case[i64] { Nil => 0, Cons(y, ys) => y}}


### PR DESCRIPTION
This removes the need to annotate the binders in clauses, i.e., we now write, e.g., `e.case[i64] { Nil => ..., Cons(x, xs) => }` instead of `e.case { Nil => ..., Cons(x : i64, xs : List[i64]) => }`.