### PR TITLE
Use appropriate type for heap size in C driver

### DIFF
--- a/infrastructure/driver-template.c
+++ b/infrastructure/driver-template.c
@@ -4,12 +4,12 @@
 
 #define ERROR_ARGUMENTS "wrong number of arguments\n"
 
-long asm_main(void *heap) asm("asm_main");
+int asm_main(void *heap) asm("asm_main");
 
 int main(int argc, char *argv[]) {
-  long val;
+  int val;
 
-  long heapsize = 1024 * 1024 * 32;
+  uint64_t heapsize = UINT64_C(1024 * 1024) * 32;
   void *heap = calloc(heapsize, sizeof(void));
 
   if (argc != 1 + 0) {

--- a/lang/driver/src/lib.rs
+++ b/lang/driver/src/lib.rs
@@ -398,8 +398,8 @@ pub fn generate_c_driver(number_of_arguments: usize, heap_size: Option<usize>) {
         .replace("asm_main(heap)", &asm_main_call);
     let c_driver = if let Some(heap_size) = heap_size {
         c_driver.replace(
-            "heapsize = 1024 * 1024 * 32",
-            &format!("heapsize = 1024 * 1024 * {heap_size}"),
+            "heapsize = UINT64_C(1024 * 1024) * 32",
+            &format!("heapsize = UINT64_C(1024 * 1024) * {heap_size}"),
         )
     } else {
         c_driver


### PR DESCRIPTION
@MarcoTz The driver now allows for larger heap sizes.