### PR TITLE
Avoid name clashes with user-defined labels

### DIFF
--- a/lang/axcut2aarch64/tests/asm/arith.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/arith.aarch64.asm
@@ -16,7 +16,7 @@ asm_main:
     ADD X1, X1, 64
     // actual code
 
-main:
+main_:
     // lit a <- 1;
     MOVZ X4, 1, LSL 0
     // lit b <- 3;

--- a/lang/axcut2aarch64/tests/asm/closure.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/closure.aarch64.asm
@@ -16,7 +16,7 @@ asm_main:
     ADD X1, X1, 64
     // actual code
 
-main:
+main_:
     // lit a <- 9;
     MOVZ X4, 9, LSL 0
     // new f: Fun = (a)\{ ... \};

--- a/lang/axcut2aarch64/tests/asm/either.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/either.aarch64.asm
@@ -16,7 +16,7 @@ asm_main:
     ADD X1, X1, 64
     // actual code
 
-main:
+main_:
     // lit z <- 1;
     MOVZ X4, 1, LSL 0
     // lit x <- 9;

--- a/lang/axcut2aarch64/tests/asm/list.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/list.aarch64.asm
@@ -16,7 +16,7 @@ asm_main:
     ADD X1, X1, 64
     // actual code
 
-main:
+main_:
     // let ws: List = Nil();
     // #mark no allocation
     MOVZ X3, 0, LSL 0

--- a/lang/axcut2aarch64/tests/asm/midi.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/midi.aarch64.asm
@@ -16,7 +16,7 @@ asm_main:
     ADD X1, X1, 64
     // actual code
 
-main:
+main_:
     // new t: ContInt = ()\{ ... \};
     // #mark no allocation
     MOVZ X3, 0, LSL 0
@@ -136,8 +136,8 @@ lab14:
     // lit n <- 3;
     MOVZ X8, 3, LSL 0
     // substitute (k !-> k)(zs !-> zs)(n !-> n);
-    // jump range
-    B range
+    // jump range_
+    B range_
 
 ContList_15:
 
@@ -181,8 +181,8 @@ lab18:
     MOV X2, X6
     MOV X6, X4
     MOV X4, X2
-    // jump sum
-    B sum
+    // jump sum_
+    B sum_
 
 ContInt_1:
 
@@ -205,7 +205,7 @@ ContInt_1_Reti:
     MOV X0, X6
     B cleanup
 
-range:
+range_:
     // if i == 0 \{ ... \}
     CMP X8, 0
     BEQ lab19
@@ -336,8 +336,8 @@ lab32:
     MOV X5, X7
     MOV X6, X8
     MOV X8, X12
-    // jump range
-    B range
+    // jump range_
+    B range_
 
 lab19:
     // substitute (xs !-> xs)(k !-> k);
@@ -351,7 +351,7 @@ lab19:
     // invoke k Retl
     BR X6
 
-sum:
+sum_:
     // switch xs \{ ... \};
     ADR X2, List_33
     ADD X2, X2, X6
@@ -530,8 +530,8 @@ lab49:
     MOV X2, X6
     MOV X6, X4
     MOV X4, X2
-    // jump sum
-    B sum
+    // jump sum_
+    B sum_
 
 ContInt_50:
 

--- a/lang/axcut2aarch64/tests/asm/mini.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/mini.aarch64.asm
@@ -16,19 +16,19 @@ asm_main:
     ADD X1, X1, 64
     // actual code
 
-main:
-    // jump l
-    B l
+main_:
+    // jump l_
+    B l_
 
-l:
+l_:
     // lit x <- 1;
     MOVZ X4, 1, LSL 0
     // lit y <- 9;
     MOVZ X6, 9, LSL 0
-    // jump j
-    B j
+    // jump j_
+    B j_
 
-j:
+j_:
     // z <- x + y;
     ADD X8, X6, X4
     // println_i64 z;

--- a/lang/axcut2aarch64/tests/asm/nonLinear.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/nonLinear.aarch64.asm
@@ -16,7 +16,7 @@ asm_main:
     ADD X1, X1, 64
     // actual code
 
-main:
+main_:
     // lit f1 <- 3;
     MOVZ X4, 3, LSL 0
     // lit f2 <- 3;

--- a/lang/axcut2aarch64/tests/asm/quad.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/quad.aarch64.asm
@@ -16,7 +16,7 @@ asm_main:
     ADD X1, X1, 64
     // actual code
 
-main:
+main_:
     // lit z <- 8;
     MOVZ X4, 8, LSL 0
     // lit y <- 6;

--- a/lang/axcut2backend/src/coder.rs
+++ b/lang/axcut2backend/src/coder.rs
@@ -45,7 +45,7 @@ where
     let mut flattened_instructions =
         Vec::with_capacity(instructions.len() + instructions.iter().map(Vec::len).sum::<usize>());
     for (mut is, name) in instructions.into_iter().zip(names) {
-        flattened_instructions.push(Backend::label(name));
+        flattened_instructions.push(Backend::label(name + "_"));
         flattened_instructions.append(&mut is);
     }
     flattened_instructions

--- a/lang/axcut2backend/src/statements/code_statement.rs
+++ b/lang/axcut2backend/src/statements/code_statement.rs
@@ -57,10 +57,11 @@ impl CodeStatement for Statement {
                 substitute.code_statement::<Backend, _, _, _>(types, context, instructions);
             }
             Statement::Call(call) => {
-                let comment = format!("{JUMP} {}", call.label);
+                let label = call.label + "_";
+                let comment = format!("{JUMP} {}", label);
                 instructions.push(Backend::comment(comment));
 
-                Backend::jump_label(call.label, instructions);
+                Backend::jump_label(label, instructions);
             }
             Statement::Let(r#let) => {
                 r#let.code_statement::<Backend, _, _, _>(types, context, instructions);

--- a/lang/axcut2rv64/tests/asm/arith.rv64.asm
+++ b/lang/axcut2rv64/tests/asm/arith.rv64.asm
@@ -1,5 +1,5 @@
 // actual code
-main:
+main_:
 // lit a <- 1;
 LI X5 1
 // lit b <- 3;

--- a/lang/axcut2rv64/tests/asm/closure.rv64.asm
+++ b/lang/axcut2rv64/tests/asm/closure.rv64.asm
@@ -1,5 +1,5 @@
 // actual code
-main:
+main_:
 // lit a <- 9;
 LI X5 9
 // new f: Fun = (a)\{ ... \};

--- a/lang/axcut2rv64/tests/asm/either.rv64.asm
+++ b/lang/axcut2rv64/tests/asm/either.rv64.asm
@@ -1,5 +1,5 @@
 // actual code
-main:
+main_:
 // lit z <- 1;
 LI X5 1
 // lit x <- 9;

--- a/lang/axcut2rv64/tests/asm/list.rv64.asm
+++ b/lang/axcut2rv64/tests/asm/list.rv64.asm
@@ -1,5 +1,5 @@
 // actual code
-main:
+main_:
 // let ws: List = Nil();
 // #mark no allocation
 MV X4 X0

--- a/lang/axcut2rv64/tests/asm/midi.rv64.asm
+++ b/lang/axcut2rv64/tests/asm/midi.rv64.asm
@@ -1,5 +1,5 @@
 // actual code
-main:
+main_:
 // new t: ContInt = ()\{ ... \};
 // #mark no allocation
 MV X4 X0
@@ -107,8 +107,8 @@ LI X7 0
 // lit n <- 3;
 LI X9 3
 // substitute (k !-> k)(zs !-> zs)(n !-> n);
-// jump range
-JAL X0 range
+// jump range_
+JAL X0 range_
 
 ContList_15:
 
@@ -150,8 +150,8 @@ MV X4 X1
 MV X1 X7
 MV X7 X5
 MV X5 X1
-// jump sum
-JAL X0 sum
+// jump sum_
+JAL X0 sum_
 
 ContInt_1:
 
@@ -160,7 +160,7 @@ ContInt_1_Reti:
 MV X10 X5
 JAL X0 cleanup
 
-range:
+range_:
 // if i == 0 \{ ... \}
 BEQ X9 X0 lab19
 // substitute (n !-> i)(k !-> k)(xs !-> xs)(i !-> i);
@@ -278,8 +278,8 @@ MV X5 X7
 MV X6 X8
 MV X7 X9
 MV X9 X13
-// jump range
-JAL X0 range
+// jump range_
+JAL X0 range_
 
 lab19:
 // substitute (xs !-> xs)(k !-> k);
@@ -293,7 +293,7 @@ MV X5 X1
 // invoke k Retl
 JALR X0 X7 0
 
-sum:
+sum_:
 // switch xs \{ ... \};
 LA X1 List_33
 ADD X1 X1 X7
@@ -458,8 +458,8 @@ MV X4 X1
 MV X1 X7
 MV X7 X5
 MV X5 X1
-// jump sum
-JAL X0 sum
+// jump sum_
+JAL X0 sum_
 
 ContInt_50:
 

--- a/lang/axcut2rv64/tests/asm/mini.rv64.asm
+++ b/lang/axcut2rv64/tests/asm/mini.rv64.asm
@@ -1,17 +1,17 @@
 // actual code
-main:
-// jump l
-JAL X0 l
+main_:
+// jump l_
+JAL X0 l_
 
-l:
+l_:
 // lit x <- 1;
 LI X5 1
 // lit y <- 9;
 LI X7 9
-// jump j
-JAL X0 j
+// jump j_
+JAL X0 j_
 
-j:
+j_:
 // z <- x + y;
 ADD X9 X7 X5
 // return z

--- a/lang/axcut2rv64/tests/asm/nonLinear.rv64.asm
+++ b/lang/axcut2rv64/tests/asm/nonLinear.rv64.asm
@@ -1,5 +1,5 @@
 // actual code
-main:
+main_:
 // lit f1 <- 3;
 LI X5 3
 // lit f2 <- 3;

--- a/lang/axcut2rv64/tests/asm/quad.rv64.asm
+++ b/lang/axcut2rv64/tests/asm/quad.rv64.asm
@@ -1,5 +1,5 @@
 // actual code
-main:
+main_:
 // lit z <- 8;
 LI X5 8
 // lit y <- 6;

--- a/lang/axcut2x86_64/tests/asm/arith.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/arith.x86_64.asm
@@ -24,7 +24,7 @@ asm_main:
     ; move parameters into place
     ; actual code
 
-main:
+main_:
     ; lit a <- 1;
     mov rdx, 1
     ; lit b <- 3;

--- a/lang/axcut2x86_64/tests/asm/closure.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/closure.x86_64.asm
@@ -24,7 +24,7 @@ asm_main:
     ; move parameters into place
     ; actual code
 
-main:
+main_:
     ; lit a <- 9;
     mov rdx, 9
     ; new f: Fun = (a)\{ ... \};

--- a/lang/axcut2x86_64/tests/asm/either.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/either.x86_64.asm
@@ -24,7 +24,7 @@ asm_main:
     ; move parameters into place
     ; actual code
 
-main:
+main_:
     ; lit z <- 1;
     mov rdx, 1
     ; lit x <- 9;

--- a/lang/axcut2x86_64/tests/asm/list.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/list.x86_64.asm
@@ -24,7 +24,7 @@ asm_main:
     ; move parameters into place
     ; actual code
 
-main:
+main_:
     ; let ws: List = Nil();
     ; #mark no allocation
     mov rax, 0

--- a/lang/axcut2x86_64/tests/asm/midi.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/midi.x86_64.asm
@@ -24,7 +24,7 @@ asm_main:
     ; move parameters into place
     ; actual code
 
-main:
+main_:
     ; new t: ContInt = ()\{ ... \};
     ; #mark no allocation
     mov rax, 0
@@ -135,8 +135,8 @@ lab14:
     ; lit n <- 3;
     mov r9, 3
     ; substitute (k !-> k)(zs !-> zs)(n !-> n);
-    ; jump range
-    jmp range
+    ; jump range_
+    jmp range_
 
 ContList_15:
 
@@ -176,8 +176,8 @@ lab18:
     mov rcx, rdi
     mov rdi, rdx
     mov rdx, rcx
-    ; jump sum
-    jmp sum
+    ; jump sum_
+    jmp sum_
 
 ContInt_1:
 
@@ -198,7 +198,7 @@ ContInt_1_Reti:
     mov rax, rdi
     jmp cleanup
 
-range:
+range_:
     ; if i == 0 \{ ... \}
     cmp r9, 0
     je lab19
@@ -321,8 +321,8 @@ lab32:
     mov rsi, r8
     mov rdi, r9
     mov r9, r13
-    ; jump range
-    jmp range
+    ; jump range_
+    jmp range_
 
 lab19:
     ; substitute (xs !-> xs)(k !-> k);
@@ -336,7 +336,7 @@ lab19:
     ; invoke k Retl
     jmp rdi
 
-sum:
+sum_:
     ; switch xs \{ ... \};
     lea rcx, [rel List_33]
     add rcx, rdi
@@ -502,8 +502,8 @@ lab49:
     mov rcx, rdi
     mov rdi, rdx
     mov rdx, rcx
-    ; jump sum
-    jmp sum
+    ; jump sum_
+    jmp sum_
 
 ContInt_50:
 

--- a/lang/axcut2x86_64/tests/asm/mini.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/mini.x86_64.asm
@@ -24,19 +24,19 @@ asm_main:
     ; move parameters into place
     ; actual code
 
-main:
-    ; jump l
-    jmp l
+main_:
+    ; jump l_
+    jmp l_
 
-l:
+l_:
     ; lit x <- 1;
     mov rdx, 1
     ; lit y <- 9;
     mov rdi, 9
-    ; jump j
-    jmp j
+    ; jump j_
+    jmp j_
 
-j:
+j_:
     ; z <- x + y;
     mov r9, rdi
     add r9, rdx

--- a/lang/axcut2x86_64/tests/asm/nonLinear.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/nonLinear.x86_64.asm
@@ -24,7 +24,7 @@ asm_main:
     ; move parameters into place
     ; actual code
 
-main:
+main_:
     ; lit f1 <- 3;
     mov rdx, 3
     ; lit f2 <- 3;

--- a/lang/axcut2x86_64/tests/asm/quad.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/quad.x86_64.asm
@@ -24,7 +24,7 @@ asm_main:
     ; move parameters into place
     ; actual code
 
-main:
+main_:
     ; lit z <- 8;
     mov rdx, 8
     ; lit y <- 6;


### PR DESCRIPTION
To avoid name clashes of user-defined labels with labels generated during code generation and with assembler keywords, this PR simply appends a `_` to every top-level label during code generation.

Closes #148.