### PR TITLE
Replace nasm assembler with yasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/setup-env
-      - uses: ilammy/setup-nasm@v1
+      - name: Install yasm
+        run: |
+          sudo apt-get update
+          sudo apt-get install yasm
       - run: cargo test --all
 
   macos-tests:

--- a/lang/driver/src/backends/x86_64.rs
+++ b/lang/driver/src/backends/x86_64.rs
@@ -69,14 +69,14 @@ impl Driver {
         let mut dist_path = Paths::x86_64_object_dir().join(file_base_name);
         dist_path.set_extension("o");
 
-        // nasm -f elf64 filename.asm
-        Command::new("nasm")
+        // yasm -f elf64 filename.asm
+        Command::new("yasm")
             .args(["-f", "elf64"])
             .args(["-o", dist_path.to_str().unwrap()])
             .arg(source_path)
             .status()
             .map_err(|_| DriverError::BinaryNotFound {
-                bin_name: "nasm".to_string(),
+                bin_name: "yasm".to_string(),
             })?;
 
         Paths::create_x86_64_binary_dir();


### PR DESCRIPTION
`nasm` is really slow for large assembly files.  `yasm` is a (at least for our purposes) drop-in replacement with a much better performance. This also fixes the problem with compilation of the nofib benchmarks (@MarcoTz).

It is a bit less actively developed at the moment, but at least on archlinux and Ubuntu it be installed directly via the package manager.