### PR TITLE
App now throws errors instead of supressing them

### DIFF
--- a/app/src/cli/codegen.rs
+++ b/app/src/cli/codegen.rs
@@ -25,21 +25,21 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
         Err(err) => return Err(drv.error_to_report(err, &cmd.filepath)),
     };
     if cmd.print_ir {
-        let _ = drv.print_compiled(&cmd.filepath, PrintMode::Textual);
-        let _ = drv.print_focused(&cmd.filepath, PrintMode::Textual);
-        let _ = drv.print_shrunk(&cmd.filepath, PrintMode::Textual);
-        let _ = drv.print_linearized(&cmd.filepath, PrintMode::Textual);
+        drv.print_compiled(&cmd.filepath, PrintMode::Textual)?;
+        drv.print_focused(&cmd.filepath, PrintMode::Textual)?;
+        drv.print_shrunk(&cmd.filepath, PrintMode::Textual)?;
+        drv.print_linearized(&cmd.filepath, PrintMode::Textual)?;
     }
 
     match cmd.backend {
         Backend::Aarch64 => {
-            let _ = drv.compile_aarch64(&cmd.filepath, cmd.heap_size);
+            drv.compile_aarch64(&cmd.filepath, cmd.heap_size)?;
         }
         Backend::Rv64 => {
-            let _ = drv.print_rv_64(&cmd.filepath, PrintMode::Textual);
+            drv.print_rv_64(&cmd.filepath, PrintMode::Textual)?;
         }
         Backend::X86_64 => {
-            let _ = drv.compile_x86_64(&cmd.filepath, cmd.heap_size);
+            drv.compile_x86_64(&cmd.filepath, cmd.heap_size)?;
         }
     }
     Ok(())

--- a/app/src/cli/compile.rs
+++ b/app/src/cli/compile.rs
@@ -15,7 +15,7 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
         Ok(compiled) => compiled,
         Err(err) => return Err(drv.error_to_report(err, &cmd.filepath)),
     };
-    let _ = drv.print_compiled(&cmd.filepath, PrintMode::Textual);
+    drv.print_compiled(&cmd.filepath, PrintMode::Textual)?;
 
     let mut stream = Box::new(StandardStream::stdout(ColorChoice::Auto));
     let _ = compiled.print_colored(&PrintCfg::default(), &mut stream);

--- a/app/src/cli/focus.rs
+++ b/app/src/cli/focus.rs
@@ -15,7 +15,7 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
         Ok(focused) => focused,
         Err(err) => return Err(drv.error_to_report(err, &cmd.filepath)),
     };
-    let _ = drv.print_focused(&cmd.filepath, PrintMode::Textual);
+    drv.print_focused(&cmd.filepath, PrintMode::Textual)?;
 
     let mut stream = Box::new(StandardStream::stdout(ColorChoice::Auto));
     let _ = focused.print_colored(&PrintCfg::default(), &mut stream);

--- a/app/src/cli/linearize.rs
+++ b/app/src/cli/linearize.rs
@@ -14,7 +14,7 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
         Ok(linearized) => linearized,
         Err(err) => return Err(drv.error_to_report(err, &cmd.filepath)),
     };
-    let _ = drv.print_linearized(&cmd.filepath, PrintMode::Textual);
+    drv.print_linearized(&cmd.filepath, PrintMode::Textual)?;
 
     let mut stream = Box::new(StandardStream::stdout(ColorChoice::Auto));
     let _ = linearized.print_colored(&PrintCfg::default(), &mut stream);

--- a/app/src/cli/shrink.rs
+++ b/app/src/cli/shrink.rs
@@ -15,7 +15,7 @@ pub fn exec(cmd: Args) -> miette::Result<()> {
         Ok(shrunk) => shrunk,
         Err(err) => return Err(drv.error_to_report(err, &cmd.filepath)),
     };
-    let _ = drv.print_shrunk(&cmd.filepath, PrintMode::Textual);
+    drv.print_shrunk(&cmd.filepath, PrintMode::Textual)?;
 
     let mut stream = Box::new(StandardStream::stdout(ColorChoice::Auto));
     let _ = shrunk.print_colored(&PrintCfg::default(), &mut stream);


### PR DESCRIPTION
The only calls that still still supress are `print_colored` as this throws an `io` error instead of a `miette` error. Not sure if we need to change this as well