### PR TITLE
Adapt names for new and cocase

### DIFF
--- a/lang/axcut/examples/midi.rs
+++ b/lang/axcut/examples/midi.rs
@@ -58,7 +58,7 @@ fn main() {
         }],
     };
 
-    let main_body = Statement::New(New {
+    let main_body = Statement::Create(Create {
         var: "t".to_string(),
         ty: Ty::Decl("ContInt".to_string()),
         context: None,
@@ -75,7 +75,7 @@ fn main() {
             })),
         }],
         free_vars_clauses: None,
-        next: Rc::new(Statement::New(New {
+        next: Rc::new(Statement::Create(Create {
             var: "k".to_string(),
             ty: Ty::Decl("ContList".to_string()),
             context: None,
@@ -225,7 +225,7 @@ fn main() {
                     },
                 ]
                 .into(),
-                body: Rc::new(Statement::New(New {
+                body: Rc::new(Statement::Create(Create {
                     var: "j".to_string(),
                     ty: Ty::Decl("ContInt".to_string()),
                     context: None,

--- a/lang/axcut/src/syntax/statements/create.rs
+++ b/lang/axcut/src/syntax/statements/create.rs
@@ -1,5 +1,5 @@
 use printer::theme::ThemeExt;
-use printer::tokens::{COLON, EQ, NEW, SEMI};
+use printer::tokens::{COLON, CREATE, EQ, SEMI};
 use printer::{DocAllocator, Print};
 
 use super::{Clause, Substitute, print_clauses};
@@ -15,7 +15,7 @@ use std::collections::HashSet;
 use std::rc::Rc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct New {
+pub struct Create {
     pub var: Var,
     pub ty: Ty,
     pub context: Option<Vec<Var>>,
@@ -25,14 +25,14 @@ pub struct New {
     pub free_vars_next: Option<HashSet<Var>>,
 }
 
-impl Print for New {
+impl Print for Create {
     fn print<'a>(
         &'a self,
         cfg: &printer::PrintCfg,
         alloc: &'a printer::Alloc<'a>,
     ) -> printer::Builder<'a> {
         alloc
-            .keyword(NEW)
+            .keyword(CREATE)
             .append(alloc.space())
             .append(&self.var)
             .append(alloc.space())
@@ -50,13 +50,13 @@ impl Print for New {
     }
 }
 
-impl From<New> for Statement {
-    fn from(value: New) -> Self {
-        Statement::New(value)
+impl From<Create> for Statement {
+    fn from(value: Create) -> Self {
+        Statement::Create(value)
     }
 }
 
-impl FreeVars for New {
+impl FreeVars for Create {
     fn free_vars(mut self, vars: &mut HashSet<Var>) -> Self {
         self.next = self.next.free_vars(vars);
         self.free_vars_next = Some(vars.clone());
@@ -72,8 +72,8 @@ impl FreeVars for New {
     }
 }
 
-impl Subst for New {
-    fn subst_sim(mut self, subst: &[(Var, Var)]) -> New {
+impl Subst for Create {
+    fn subst_sim(mut self, subst: &[(Var, Var)]) -> Create {
         self.clauses = self.clauses.subst_sim(subst);
         self.next = self.next.subst_sim(subst);
         self.free_vars_clauses = self.free_vars_clauses.subst_sim(subst);
@@ -82,7 +82,7 @@ impl Subst for New {
     }
 }
 
-impl Linearizing for New {
+impl Linearizing for Create {
     type Target = Statement;
     fn linearize(mut self, mut context: Vec<Var>, used_vars: &mut HashSet<Var>) -> Statement {
         let free_vars_clauses = std::mem::take(&mut self.free_vars_clauses)

--- a/lang/axcut/src/syntax/statements/mod.rs
+++ b/lang/axcut/src/syntax/statements/mod.rs
@@ -1,12 +1,12 @@
 pub mod call;
 pub mod clause;
+pub mod create;
 pub mod exit;
 pub mod ifc;
 pub mod ifz;
 pub mod invoke;
 pub mod r#let;
 pub mod literal;
-pub mod new;
 pub mod op;
 pub mod print;
 pub mod substitute;
@@ -14,13 +14,13 @@ pub mod switch;
 
 pub use call::Call;
 pub use clause::{Clause, print_clauses};
+pub use create::Create;
 pub use exit::Exit;
 pub use ifc::IfC;
 pub use ifz::IfZ;
 pub use invoke::Invoke;
 pub use r#let::Let;
 pub use literal::Literal;
-pub use new::New;
 pub use op::Op;
 pub use print::PrintI64;
 pub use substitute::Substitute;
@@ -41,7 +41,7 @@ pub enum Statement {
     Call(Call),
     Let(Let),
     Switch(Switch),
-    New(New),
+    Create(Create),
     Invoke(Invoke),
     Literal(Literal),
     Op(Op),
@@ -58,7 +58,7 @@ impl FreeVars for Statement {
             Statement::Call(call) => call.free_vars(vars).into(),
             Statement::Let(r#let) => r#let.free_vars(vars).into(),
             Statement::Switch(swich) => swich.free_vars(vars).into(),
-            Statement::New(new) => new.free_vars(vars).into(),
+            Statement::Create(create) => create.free_vars(vars).into(),
             Statement::Invoke(invoke) => invoke.free_vars(vars).into(),
             Statement::Literal(lit) => lit.free_vars(vars).into(),
             Statement::Op(op) => op.free_vars(vars).into(),
@@ -80,7 +80,7 @@ impl Subst for Statement {
             Statement::Call(call) => call.subst_sim(subst).into(),
             Statement::Let(r#let) => r#let.subst_sim(subst).into(),
             Statement::Switch(switch) => switch.subst_sim(subst).into(),
-            Statement::New(new) => new.subst_sim(subst).into(),
+            Statement::Create(create) => create.subst_sim(subst).into(),
             Statement::Invoke(invoke) => invoke.subst_sim(subst).into(),
             Statement::Literal(lit) => lit.subst_sim(subst).into(),
             Statement::Op(op) => op.subst_sim(subst).into(),
@@ -102,7 +102,7 @@ impl Linearizing for Statement {
             Statement::Call(call) => call.linearize(context, used_vars),
             Statement::Let(r#let) => r#let.linearize(context, used_vars),
             Statement::Switch(switch) => switch.linearize(context, used_vars),
-            Statement::New(new) => new.linearize(context, used_vars),
+            Statement::Create(create) => create.linearize(context, used_vars),
             Statement::Invoke(invoke) => invoke.linearize(context, used_vars),
             Statement::Literal(lit) => lit.linearize(context, used_vars),
             Statement::Op(op) => op.linearize(context, used_vars),
@@ -125,7 +125,7 @@ impl Print for Statement {
             Statement::Call(call) => call.print(cfg, alloc),
             Statement::Let(r#let) => r#let.print(cfg, alloc),
             Statement::Switch(switch) => switch.print(cfg, alloc),
-            Statement::New(new) => new.print(cfg, alloc),
+            Statement::Create(create) => create.print(cfg, alloc),
             Statement::Invoke(invoke) => invoke.print(cfg, alloc),
             Statement::Literal(lit) => lit.print(cfg, alloc),
             Statement::Op(op) => op.print(cfg, alloc),

--- a/lang/axcut2aarch64/tests/asm/closure.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/closure.aarch64.asm
@@ -21,7 +21,7 @@ asm_main:
 main_:
     // lit a <- 9;
     MOVZ X5, 9, LSL 0
-    // new f: Fun = (a)\{ ... \};
+    // create f: Fun = (a)\{ ... \};
     // #allocate memory
     // ##store values
     STR X5, [ X0, 56 ]
@@ -123,7 +123,7 @@ lab11:
 lab13:
     // #load tag
     ADR X5, Fun_14
-    // new k: Cont = ()\{ ... \};
+    // create k: Cont = ()\{ ... \};
     // #mark no allocation
     MOVZ X6, 0, LSL 0
     // #load tag

--- a/lang/axcut2aarch64/tests/asm/midi.aarch64.asm
+++ b/lang/axcut2aarch64/tests/asm/midi.aarch64.asm
@@ -19,12 +19,12 @@ asm_main:
     // actual code
 
 main_:
-    // new t: ContInt = ()\{ ... \};
+    // create t: ContInt = ()\{ ... \};
     // #mark no allocation
     MOVZ X4, 0, LSL 0
     // #load tag
     ADR X5, ContInt_1
-    // new k: ContList = (t)\{ ... \};
+    // create k: ContList = (t)\{ ... \};
     // #allocate memory
     // ##store values
     STR X5, [ X0, 56 ]
@@ -409,7 +409,7 @@ lab36:
     MOV X2, X7
     MOV X7, X5
     MOV X5, X2
-    // new j: ContInt = (k, y)\{ ... \};
+    // create j: ContInt = (k, y)\{ ... \};
     // #allocate memory
     // ##store values
     STR X9, [ X0, 56 ]

--- a/lang/axcut2aarch64/tests/closure.rs
+++ b/lang/axcut2aarch64/tests/closure.rs
@@ -47,7 +47,7 @@ fn test_closure() {
     let main_body = Statement::Literal(Literal {
         lit: 9,
         var: "a".to_string(),
-        next: Rc::new(Statement::New(New {
+        next: Rc::new(Statement::Create(Create {
             var: "f".to_string(),
             ty: Ty::Decl("Fun".to_string()),
             context: Some(vec!["a".to_string()]),
@@ -87,7 +87,7 @@ fn test_closure() {
                 })),
             }],
             free_vars_clauses: None,
-            next: Rc::new(Statement::New(New {
+            next: Rc::new(Statement::Create(Create {
                 var: "k".to_string(),
                 ty: Ty::Decl("Cont".to_string()),
                 context: Some(Vec::new()),

--- a/lang/axcut2aarch64/tests/midi.rs
+++ b/lang/axcut2aarch64/tests/midi.rs
@@ -63,7 +63,7 @@ fn test_midi() {
         }],
     };
 
-    let main_body = Statement::New(New {
+    let main_body = Statement::Create(Create {
         var: "t".to_string(),
         ty: Ty::Decl("ContInt".to_string()),
         context: Some(Vec::new()),
@@ -90,7 +90,7 @@ fn test_midi() {
             })),
         }],
         free_vars_clauses: None,
-        next: Rc::new(Statement::New(New {
+        next: Rc::new(Statement::Create(Create {
             var: "k".to_string(),
             ty: Ty::Decl("ContList".to_string()),
             context: Some(vec!["t".to_string()]),
@@ -272,7 +272,7 @@ fn test_midi() {
                         ("k".to_string(), "k".to_string()),
                         ("y".to_string(), "y".to_string()),
                     ],
-                    next: Rc::new(Statement::New(New {
+                    next: Rc::new(Statement::Create(Create {
                         var: "j".to_string(),
                         ty: Ty::Decl("ContInt".to_string()),
                         context: Some(vec!["k".to_string(), "y".to_string()]),

--- a/lang/axcut2backend/src/statements/code_statement.rs
+++ b/lang/axcut2backend/src/statements/code_statement.rs
@@ -69,7 +69,7 @@ impl CodeStatement for Statement {
             Statement::Switch(switch) => {
                 switch.code_statement::<Backend, _, _, _>(types, context, instructions);
             }
-            Statement::New(new) => {
+            Statement::Create(new) => {
                 new.code_statement::<Backend, _, _, _>(types, context, instructions);
             }
             Statement::Invoke(invoke) => {

--- a/lang/axcut2backend/src/statements/create.rs
+++ b/lang/axcut2backend/src/statements/create.rs
@@ -1,4 +1,4 @@
-use printer::{Print, tokens::NEW};
+use printer::{Print, tokens::CREATE};
 
 use super::CodeStatement;
 use crate::fresh_labels::fresh_label;
@@ -10,11 +10,13 @@ use crate::{
     parallel_moves::ParallelMoves,
     utils::Utils,
 };
-use axcut::syntax::{Chirality, ContextBinding, TypeDeclaration, TypingContext, statements::New};
+use axcut::syntax::{
+    Chirality, ContextBinding, TypeDeclaration, TypingContext, statements::Create,
+};
 
 use std::hash::Hash;
 
-impl CodeStatement for New {
+impl CodeStatement for Create {
     fn code_statement<Backend, Code, Temporary: Ord + Hash + Copy, Immediate>(
         self,
         types: &[TypeDeclaration],
@@ -28,7 +30,7 @@ impl CodeStatement for New {
             + Utils<Temporary>,
     {
         let comment = format!(
-            "{NEW} {}: {} = ({})\\{{ ... \\}};",
+            "{CREATE} {}: {} = ({})\\{{ ... \\}};",
             self.var,
             self.ty.print_to_string(None),
             self.context.print_to_string(None)

--- a/lang/axcut2backend/src/statements/mod.rs
+++ b/lang/axcut2backend/src/statements/mod.rs
@@ -1,10 +1,10 @@
 pub mod code_statement;
+pub mod create;
 pub mod ifc;
 pub mod ifz;
 pub mod invoke;
 pub mod r#let;
 pub mod literal;
-pub mod new;
 pub mod op;
 pub mod print;
 pub mod ret;

--- a/lang/axcut2rv64/tests/asm/closure.rv64.asm
+++ b/lang/axcut2rv64/tests/asm/closure.rv64.asm
@@ -2,7 +2,7 @@
 main_:
 // lit a <- 9;
 LI X5 9
-// new f: Fun = (a)\{ ... \};
+// create f: Fun = (a)\{ ... \};
 // #allocate memory
 // ##store values
 SW X5 56 X2
@@ -96,7 +96,7 @@ lab11:
 lab13:
 // #load tag
 LA X5 Fun_14
-// new k: Cont = ()\{ ... \};
+// create k: Cont = ()\{ ... \};
 // #mark no allocation
 MV X6 X0
 // #load tag

--- a/lang/axcut2rv64/tests/asm/midi.rv64.asm
+++ b/lang/axcut2rv64/tests/asm/midi.rv64.asm
@@ -1,11 +1,11 @@
 // actual code
 main_:
-// new t: ContInt = ()\{ ... \};
+// create t: ContInt = ()\{ ... \};
 // #mark no allocation
 MV X4 X0
 // #load tag
 LA X5 ContInt_1
-// new k: ContList = (t)\{ ... \};
+// create k: ContList = (t)\{ ... \};
 // #allocate memory
 // ##store values
 SW X5 56 X2
@@ -355,7 +355,7 @@ MV X4 X1
 MV X1 X7
 MV X7 X5
 MV X5 X1
-// new j: ContInt = (k, y)\{ ... \};
+// create j: ContInt = (k, y)\{ ... \};
 // #allocate memory
 // ##store values
 SW X9 56 X2

--- a/lang/axcut2rv64/tests/closure.rs
+++ b/lang/axcut2rv64/tests/closure.rs
@@ -46,7 +46,7 @@ fn test_closure() {
     let main_body = Statement::Literal(Literal {
         lit: 9,
         var: "a".to_string(),
-        next: Rc::new(Statement::New(New {
+        next: Rc::new(Statement::Create(Create {
             var: "f".to_string(),
             ty: Ty::Decl("Fun".to_string()),
             context: Some(vec!["a".to_string()]),
@@ -86,7 +86,7 @@ fn test_closure() {
                 })),
             }],
             free_vars_clauses: None,
-            next: Rc::new(Statement::New(New {
+            next: Rc::new(Statement::Create(Create {
                 var: "k".to_string(),
                 ty: Ty::Decl("Cont".to_string()),
                 context: Some(Vec::new()),

--- a/lang/axcut2rv64/tests/midi.rs
+++ b/lang/axcut2rv64/tests/midi.rs
@@ -62,7 +62,7 @@ fn test_midi() {
         }],
     };
 
-    let main_body = Statement::New(New {
+    let main_body = Statement::Create(Create {
         var: "t".to_string(),
         ty: Ty::Decl("ContInt".to_string()),
         context: Some(Vec::new()),
@@ -79,7 +79,7 @@ fn test_midi() {
             })),
         }],
         free_vars_clauses: None,
-        next: Rc::new(Statement::New(New {
+        next: Rc::new(Statement::Create(Create {
             var: "k".to_string(),
             ty: Ty::Decl("ContList".to_string()),
             context: Some(vec!["t".to_string()]),
@@ -261,7 +261,7 @@ fn test_midi() {
                         ("k".to_string(), "k".to_string()),
                         ("y".to_string(), "y".to_string()),
                     ],
-                    next: Rc::new(Statement::New(New {
+                    next: Rc::new(Statement::Create(Create {
                         var: "j".to_string(),
                         ty: Ty::Decl("ContInt".to_string()),
                         context: Some(vec!["k".to_string(), "y".to_string()]),

--- a/lang/axcut2x86_64/tests/asm/closure.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/closure.x86_64.asm
@@ -27,7 +27,7 @@ asm_main:
 main_:
     ; lit a <- 9;
     mov rdx, 9
-    ; new f: Fun = (a)\{ ... \};
+    ; create f: Fun = (a)\{ ... \};
     ; #allocate memory
     ; ##store values
     mov [rbx + 56], rdx
@@ -124,7 +124,7 @@ lab11:
 lab13:
     ; #load tag
     lea rdx, [rel Fun_14]
-    ; new k: Cont = ()\{ ... \};
+    ; create k: Cont = ()\{ ... \};
     ; #mark no allocation
     mov rsi, 0
     ; #load tag

--- a/lang/axcut2x86_64/tests/asm/midi.x86_64.asm
+++ b/lang/axcut2x86_64/tests/asm/midi.x86_64.asm
@@ -25,12 +25,12 @@ asm_main:
     ; actual code
 
 main_:
-    ; new t: ContInt = ()\{ ... \};
+    ; create t: ContInt = ()\{ ... \};
     ; #mark no allocation
     mov rax, 0
     ; #load tag
     lea rdx, [rel ContInt_1]
-    ; new k: ContList = (t)\{ ... \};
+    ; create k: ContList = (t)\{ ... \};
     ; #allocate memory
     ; ##store values
     mov [rbx + 56], rdx
@@ -396,7 +396,7 @@ lab36:
     mov rcx, rdi
     mov rdi, rdx
     mov rdx, rcx
-    ; new j: ContInt = (k, y)\{ ... \};
+    ; create j: ContInt = (k, y)\{ ... \};
     ; #allocate memory
     ; ##store values
     mov [rbx + 56], r9

--- a/lang/axcut2x86_64/tests/closure.rs
+++ b/lang/axcut2x86_64/tests/closure.rs
@@ -47,7 +47,7 @@ fn test_closure() {
     let main_body = Statement::Literal(Literal {
         lit: 9,
         var: "a".to_string(),
-        next: Rc::new(Statement::New(New {
+        next: Rc::new(Statement::Create(Create {
             var: "f".to_string(),
             ty: Ty::Decl("Fun".to_string()),
             context: Some(vec!["a".to_string()]),
@@ -87,7 +87,7 @@ fn test_closure() {
                 })),
             }],
             free_vars_clauses: None,
-            next: Rc::new(Statement::New(New {
+            next: Rc::new(Statement::Create(Create {
                 var: "k".to_string(),
                 ty: Ty::Decl("Cont".to_string()),
                 context: Some(Vec::new()),

--- a/lang/axcut2x86_64/tests/midi.rs
+++ b/lang/axcut2x86_64/tests/midi.rs
@@ -63,7 +63,7 @@ fn test_midi() {
         }],
     };
 
-    let main_body = Statement::New(New {
+    let main_body = Statement::Create(Create {
         var: "t".to_string(),
         ty: Ty::Decl("ContInt".to_string()),
         context: Some(Vec::new()),
@@ -90,7 +90,7 @@ fn test_midi() {
             })),
         }],
         free_vars_clauses: None,
-        next: Rc::new(Statement::New(New {
+        next: Rc::new(Statement::Create(Create {
             var: "k".to_string(),
             ty: Ty::Decl("ContList".to_string()),
             context: Some(vec!["t".to_string()]),
@@ -272,7 +272,7 @@ fn test_midi() {
                         ("k".to_string(), "k".to_string()),
                         ("y".to_string(), "y".to_string()),
                     ],
-                    next: Rc::new(Statement::New(New {
+                    next: Rc::new(Statement::Create(Create {
                         var: "j".to_string(),
                         ty: Ty::Decl("ContInt".to_string()),
                         context: Some(vec!["k".to_string(), "y".to_string()]),

--- a/lang/core2axcut/src/statements/cut.rs
+++ b/lang/core2axcut/src/statements/cut.rs
@@ -159,7 +159,7 @@ fn shrink_critical_pairs(
     state: &mut ShrinkingState,
 ) -> axcut::syntax::Statement {
     match ty.clone() {
-        Ty::I64 => axcut::syntax::statements::New {
+        Ty::I64 => axcut::syntax::statements::Create {
             var: var_prd,
             ty: axcut::syntax::Ty::Decl(cont_int().name),
             context: None,
@@ -262,7 +262,7 @@ fn shrink_critical_pairs(
                 })
                 .collect();
 
-            axcut::syntax::statements::New {
+            axcut::syntax::statements::Create {
                 var: var_keep,
                 ty: axcut::syntax::Ty::Decl(name),
                 context: None,
@@ -624,7 +624,7 @@ impl Shrinking for FsCut {
                     clauses,
                     ..
                 }),
-            ) => axcut::syntax::statements::New {
+            ) => axcut::syntax::statements::Create {
                 var: variable,
                 ty: shrink_ty(self.ty),
                 context: None,
@@ -646,7 +646,7 @@ impl Shrinking for FsCut {
                     statement,
                     ..
                 }),
-            ) => axcut::syntax::statements::New {
+            ) => axcut::syntax::statements::Create {
                 var: variable,
                 ty: shrink_ty(self.ty),
                 context: None,

--- a/lang/core_lang/src/syntax/terms/xcase.rs
+++ b/lang/core_lang/src/syntax/terms/xcase.rs
@@ -1,7 +1,7 @@
 use printer::{
     DocAllocator, Print,
     theme::ThemeExt,
-    tokens::{CASE, COCASE},
+    tokens::{CASE, NEW},
     util::BracesExt,
 };
 
@@ -36,7 +36,7 @@ impl<T: PrdCns, S: Print> Print for XCase<T, S> {
         alloc: &'a printer::Alloc<'a>,
     ) -> printer::Builder<'a> {
         if self.prdcns.is_prd() {
-            alloc.keyword(COCASE).append(alloc.space()).append(
+            alloc.keyword(NEW).append(alloc.space()).append(
                 alloc
                     .space()
                     .append(self.clauses.print(cfg, alloc))

--- a/lang/printer/src/tokens.rs
+++ b/lang/printer/src/tokens.rs
@@ -108,8 +108,8 @@ pub const PRINTLN_I64: &str = "println_i64";
 /// The keyword `case`
 pub const CASE: &str = "case";
 
-/// The keyword `cocase`
-pub const COCASE: &str = "cocase";
+/// The keyword `new`
+pub const NEW: &str = "new";
 
 /// The keyword `if`
 pub const IF: &str = "if";
@@ -132,8 +132,8 @@ pub const I64: &str = "i64";
 /// The keyword `invoke`
 pub const INVOKE: &str = "invoke";
 
-/// The keyword `new`
-pub const NEW: &str = "new";
+/// The keyword `create`
+pub const CREATE: &str = "create";
 
 /// The keyword `switch`
 pub const SWITCH: &str = "switch";


### PR DESCRIPTION
This just adapts names for `new` and `cocase` according to the paper.