### PR TITLE
Remove corelang duplication

### DIFF
--- a/lang/core2axcut/src/statements/print.rs
+++ b/lang/core2axcut/src/statements/print.rs
@@ -10,7 +10,7 @@ impl Shrinking for FsPrintI64 {
     fn shrink(self, state: &mut ShrinkingState) -> axcut::syntax::Statement {
         axcut::syntax::Statement::PrintI64(axcut::syntax::statements::PrintI64 {
             newline: self.newline,
-            var: self.var,
+            var: self.arg,
             next: self.next.shrink(state),
             free_vars_next: None,
         })

--- a/lang/core_lang/src/syntax/def.rs
+++ b/lang/core_lang/src/syntax/def.rs
@@ -12,16 +12,18 @@ use std::collections::HashSet;
 /// (unique in the program), a typing context defining the parameters, and the body statement. It
 /// is annotated with the list of all variable names used in the top-level function.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Def {
+pub struct Def<S = Statement> {
     /// The name of the definition
     pub name: Name,
     /// The parameter context
     pub context: TypingContext,
     /// The body statement
-    pub body: Statement,
+    pub body: S,
     /// Variable names used in the top-level function
     pub used_vars: HashSet<Var>,
 }
+
+pub type FsDef = Def<FsStatement>;
 
 impl Def {
     /// This function applies the [`Focusing`] transformation to the body of the top-level function.
@@ -35,40 +37,7 @@ impl Def {
     }
 }
 
-impl Print for Def {
-    fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
-        let head = alloc
-            .keyword(DEF)
-            .append(alloc.space())
-            .append(self.name.print(cfg, alloc))
-            .append(self.context.print(cfg, alloc).parens())
-            .append(alloc.space());
-
-        let body = alloc
-            .hardline()
-            .append(self.body.print(cfg, alloc).group())
-            .nest(cfg.indent)
-            .append(alloc.hardline())
-            .braces_anno();
-
-        head.group().append(body)
-    }
-}
-
-/// This struct defines the focused version of top-level function [`Def`]efinitions.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FsDef {
-    /// The name of the definition
-    pub name: Name,
-    /// The parameter context
-    pub context: TypingContext,
-    /// The body statement
-    pub body: FsStatement,
-    /// Variable names used in the top-level function
-    pub used_vars: HashSet<Var>,
-}
-
-impl Print for FsDef {
+impl<S: Print> Print for Def<S> {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let head = alloc
             .keyword(DEF)

--- a/lang/core_lang/src/syntax/statements/ifc.rs
+++ b/lang/core_lang/src/syntax/statements/ifc.rs
@@ -43,18 +43,20 @@ impl Print for IfSort {
 /// consists of the comparison operation, the first term and an optional second term, and the
 /// then-branch and else-branch, and after typechecking also of the inferred type.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IfC {
+pub struct IfC<P = Rc<Term<Prd>>, S = Statement> {
     /// The comparison operation
     pub sort: IfSort,
     /// The first term of the comparison
-    pub fst: Rc<Term<Prd>>,
+    pub fst: P,
     /// The optional second term of the comparison
-    pub snd: Option<Rc<Term<Prd>>>,
+    pub snd: Option<P>,
     /// The then-branch
-    pub thenc: Rc<Statement>,
+    pub thenc: Rc<S>,
     /// The else-branch
-    pub elsec: Rc<Statement>,
+    pub elsec: Rc<S>,
 }
+
+pub type FsIfC = IfC<Var, FsStatement>;
 
 impl IfC {
     /// This function creates a conditional with `==` comparison for given operands and then- and
@@ -117,7 +119,11 @@ impl Typed for IfC {
     }
 }
 
-impl Print for IfC {
+impl<P, S> Print for IfC<P, S>
+where
+    P: Print,
+    S: Print,
+{
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let snd = match self.snd {
             None => alloc.text(ZERO),
@@ -160,6 +166,12 @@ impl From<IfC> for Statement {
     }
 }
 
+impl From<FsIfC> for FsStatement {
+    fn from(value: FsIfC) -> Self {
+        FsStatement::IfC(value)
+    }
+}
+
 impl Subst for IfC {
     type Target = IfC;
     fn subst_sim(
@@ -177,10 +189,42 @@ impl Subst for IfC {
     }
 }
 
+impl SubstVar for FsIfC {
+    type Target = FsIfC;
+    fn subst_sim(mut self, subst: &[(Var, Var)]) -> FsIfC {
+        self.fst = self.fst.subst_sim(subst);
+        self.snd = self.snd.subst_sim(subst);
+
+        self.thenc = self.thenc.subst_sim(subst);
+        self.elsec = self.elsec.subst_sim(subst);
+
+        self
+    }
+}
+
 impl TypedFreeVars for IfC {
     fn typed_free_vars(&self, vars: &mut BTreeSet<ContextBinding>) {
         self.fst.typed_free_vars(vars);
         self.snd.typed_free_vars(vars);
+        self.thenc.typed_free_vars(vars);
+        self.elsec.typed_free_vars(vars);
+    }
+}
+
+impl TypedFreeVars for FsIfC {
+    fn typed_free_vars(&self, vars: &mut BTreeSet<ContextBinding>) {
+        vars.insert(ContextBinding {
+            var: self.fst.clone(),
+            chi: Chirality::Prd,
+            ty: Ty::I64,
+        });
+        if let Some(var) = self.snd.clone() {
+            vars.insert(ContextBinding {
+                var,
+                chi: Chirality::Prd,
+                ty: Ty::I64,
+            });
+        }
         self.thenc.typed_free_vars(vars);
         self.elsec.typed_free_vars(vars);
     }
@@ -237,96 +281,6 @@ impl Focusing for IfC {
             ),
             used_vars,
         )
-    }
-}
-
-/// This struct defines the focused version of conditional [`IfC`] statements.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FsIfC {
-    /// The comparison operation
-    pub sort: IfSort,
-    /// The first variable of the comparison
-    pub fst: Var,
-    /// The optional second variable of the comparison
-    pub snd: Option<Var>,
-    /// The then-branch
-    pub thenc: Rc<FsStatement>,
-    /// The else-branch
-    pub elsec: Rc<FsStatement>,
-}
-
-impl Print for FsIfC {
-    fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
-        let snd = match self.snd {
-            None => alloc.text(ZERO),
-            Some(ref snd) => snd.print(cfg, alloc),
-        };
-        alloc
-            .keyword(IF)
-            .append(alloc.space())
-            .append(self.fst.print(cfg, alloc))
-            .append(alloc.space())
-            .append(self.sort.print(cfg, alloc))
-            .append(alloc.space())
-            .append(snd)
-            .append(alloc.space())
-            .append(
-                alloc
-                    .line()
-                    .append(self.thenc.print(cfg, alloc).group())
-                    .nest(cfg.indent)
-                    .append(alloc.line())
-                    .braces_anno(),
-            )
-            .append(alloc.space())
-            .append(alloc.keyword(ELSE))
-            .append(alloc.space())
-            .append(
-                alloc
-                    .line()
-                    .append(self.elsec.print(cfg, alloc).group())
-                    .nest(cfg.indent)
-                    .append(alloc.line())
-                    .braces_anno(),
-            )
-    }
-}
-
-impl From<FsIfC> for FsStatement {
-    fn from(value: FsIfC) -> Self {
-        FsStatement::IfC(value)
-    }
-}
-
-impl SubstVar for FsIfC {
-    type Target = FsIfC;
-    fn subst_sim(mut self, subst: &[(Var, Var)]) -> FsIfC {
-        self.fst = self.fst.subst_sim(subst);
-        self.snd = self.snd.subst_sim(subst);
-
-        self.thenc = self.thenc.subst_sim(subst);
-        self.elsec = self.elsec.subst_sim(subst);
-
-        self
-    }
-}
-
-impl TypedFreeVars for FsIfC {
-    fn typed_free_vars(&self, vars: &mut BTreeSet<ContextBinding>) {
-        vars.insert(ContextBinding {
-            var: self.fst.clone(),
-            chi: Chirality::Prd,
-            ty: Ty::I64,
-        });
-        if let Some(var) = self.snd.clone() {
-            vars.insert(ContextBinding {
-                var,
-                chi: Chirality::Prd,
-                ty: Ty::I64,
-            });
-        }
-        self.thenc.typed_free_vars(vars);
-        self.elsec.typed_free_vars(vars);
     }
 }
 

--- a/lang/core_lang/src/syntax/statements/print.rs
+++ b/lang/core_lang/src/syntax/statements/print.rs
@@ -12,14 +12,16 @@ use std::rc::Rc;
 /// This struct defines printing an integer in Core. It consists of the information whether a
 /// newline should be printed, the term for the integer to print, and the remaining statement.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PrintI64 {
+pub struct PrintI64<P = Rc<Term<Prd>>, S = Statement> {
     /// Whether to print a newline after the value
     pub newline: bool,
     /// The term for the integer to be printed
-    pub arg: Rc<Term<Prd>>,
+    pub arg: P,
     /// The next statement after the print
-    pub next: Rc<Statement>,
+    pub next: Rc<S>,
 }
+
+pub type FsPrintI64 = PrintI64<Var, FsStatement>;
 
 impl PrintI64 {
     /// This function creates a new print statement from an argument and a remaining statement.
@@ -42,7 +44,11 @@ impl Typed for PrintI64 {
     }
 }
 
-impl Print for PrintI64 {
+impl<P, S> Print for PrintI64<P, S>
+where
+    P: Print,
+    S: Print,
+{
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         let print_i64 = if self.newline { PRINTLN_I64 } else { PRINT_I64 };
         alloc
@@ -68,6 +74,12 @@ impl From<PrintI64> for Statement {
     }
 }
 
+impl From<FsPrintI64> for FsStatement {
+    fn from(value: FsPrintI64) -> Self {
+        FsStatement::PrintI64(value)
+    }
+}
+
 impl Subst for PrintI64 {
     type Target = PrintI64;
     fn subst_sim(
@@ -81,9 +93,29 @@ impl Subst for PrintI64 {
     }
 }
 
+impl SubstVar for FsPrintI64 {
+    type Target = FsPrintI64;
+    fn subst_sim(mut self, subst: &[(Var, Var)]) -> FsPrintI64 {
+        self.arg = self.arg.subst_sim(subst);
+        self.next = self.next.subst_sim(subst);
+        self
+    }
+}
+
 impl TypedFreeVars for PrintI64 {
     fn typed_free_vars(&self, vars: &mut BTreeSet<ContextBinding>) {
         self.arg.typed_free_vars(vars);
+        self.next.typed_free_vars(vars);
+    }
+}
+
+impl TypedFreeVars for FsPrintI64 {
+    fn typed_free_vars(&self, vars: &mut BTreeSet<ContextBinding>) {
+        vars.insert(ContextBinding {
+            var: self.arg.clone(),
+            chi: Chirality::Prd,
+            ty: Ty::I64,
+        });
         self.next.typed_free_vars(vars);
     }
 }
@@ -105,7 +137,7 @@ impl Focusing for PrintI64 {
                 move |binding: ContextBinding, used_vars: &mut HashSet<Var>| {
                     FsPrintI64 {
                         newline: self.newline,
-                        var: binding.var,
+                        arg: binding.var,
                         next: self.next.focus(used_vars),
                     }
                     .into()
@@ -113,54 +145,5 @@ impl Focusing for PrintI64 {
             ),
             used_vars,
         )
-    }
-}
-
-/// This struct defines the focused version of the [`PrintI64`] statement.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FsPrintI64 {
-    /// Whether to print a newline after the value
-    pub newline: bool,
-    /// The integer to print (always a variable here)
-    pub var: Var,
-    /// The next statement after the print
-    pub next: Rc<FsStatement>,
-}
-
-impl Print for FsPrintI64 {
-    fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
-        let print_i64 = if self.newline { PRINTLN_I64 } else { PRINT_I64 };
-        alloc
-            .keyword(print_i64)
-            .append(self.var.print(cfg, alloc).parens())
-            .append(SEMI)
-            .append(alloc.line())
-            .append(self.next.print(cfg, alloc))
-    }
-}
-
-impl From<FsPrintI64> for FsStatement {
-    fn from(value: FsPrintI64) -> Self {
-        FsStatement::PrintI64(value)
-    }
-}
-
-impl SubstVar for FsPrintI64 {
-    type Target = FsPrintI64;
-    fn subst_sim(mut self, subst: &[(Var, Var)]) -> FsPrintI64 {
-        self.var = self.var.subst_sim(subst);
-        self.next = self.next.subst_sim(subst);
-        self
-    }
-}
-
-impl TypedFreeVars for FsPrintI64 {
-    fn typed_free_vars(&self, vars: &mut BTreeSet<ContextBinding>) {
-        vars.insert(ContextBinding {
-            var: self.var.clone(),
-            chi: Chirality::Prd,
-            ty: Ty::I64,
-        });
-        self.next.typed_free_vars(vars);
     }
 }


### PR DESCRIPTION
Use a parameterized struct if the unfocused and focused variant share most of the structure.