### PR TITLE
Fix translation of destructor invocation

### DIFF
--- a/examples/Destructor/Destructor.args
+++ b/examples/Destructor/Destructor.args
@@ -1,0 +1,2 @@
+test_args = []
+expected = "10\n10"

--- a/examples/Destructor/Destructor.sc
+++ b/examples/Destructor/Destructor.sc
@@ -1,0 +1,6 @@
+codata Stream { apply(x: i64): i64 }
+
+def main() : i64 {
+  let i: i64 = (println_i64(0); new { apply(x) => x }).apply(print_i64(1); 42);
+  (label a { println_i64(0); new { apply(x) => x } }).apply(print_i64(1); 42)
+}

--- a/lang/core_lang/src/syntax/arguments.rs
+++ b/lang/core_lang/src/syntax/arguments.rs
@@ -37,6 +37,24 @@ impl From<Term<Cns>> for Argument {
     }
 }
 
+impl Typed for Argument {
+    fn get_type(&self) -> Ty {
+        match self {
+            Argument::Producer(prd) => prd.get_type(),
+            Argument::Consumer(cns) => cns.get_type(),
+        }
+    }
+}
+
+impl IsCoValue for Argument {
+    fn is_co_value(&self, codata_types: &[CodataDeclaration]) -> bool {
+        match self {
+            Argument::Producer(prd) => prd.is_value(codata_types),
+            Argument::Consumer(cns) => cns.is_covalue(codata_types),
+        }
+    }
+}
+
 impl Subst for Argument {
     type Target = Argument;
     fn subst_sim(
@@ -112,8 +130,22 @@ impl Print for Arguments {
 }
 
 impl From<Arguments> for VecDeque<Argument> {
-    fn from(s: Arguments) -> VecDeque<Argument> {
-        s.entries.into()
+    fn from(args: Arguments) -> VecDeque<Argument> {
+        args.entries.into()
+    }
+}
+
+impl From<VecDeque<Argument>> for Arguments {
+    fn from(args: VecDeque<Argument>) -> Arguments {
+        Arguments {
+            entries: args.into(),
+        }
+    }
+}
+
+impl IsCoValue for Arguments {
+    fn is_co_value(&self, codata_types: &[CodataDeclaration]) -> bool {
+        self.entries.is_co_value(codata_types)
     }
 }
 

--- a/lang/core_lang/src/syntax/terms/mod.rs
+++ b/lang/core_lang/src/syntax/terms/mod.rs
@@ -103,6 +103,34 @@ impl<C: Chi> Print for Term<C> {
     }
 }
 
+impl IsValue for Term<Prd> {
+    fn is_value(&self, codata_types: &[CodataDeclaration]) -> bool {
+        if self.get_type().is_codata(codata_types) {
+            true
+        } else {
+            match self {
+                Term::Op(_) | Term::Mu(_) => false,
+                Term::Xtor(xtor) => xtor.args.is_co_value(codata_types),
+                Term::XVar(_) | Term::Literal(_) | Term::XCase(_) => true,
+            }
+        }
+    }
+}
+impl IsCovalue for Term<Cns> {
+    fn is_covalue(&self, codata_types: &[CodataDeclaration]) -> bool {
+        if !self.get_type().is_codata(codata_types) {
+            true
+        } else {
+            match self {
+                Term::Mu(_) => false,
+                Term::Xtor(xtor) => xtor.args.is_co_value(codata_types),
+                Term::XVar(_) | Term::XCase(_) => true,
+                Term::Literal(_) | Term::Op(_) => panic!("cannot happen"),
+            }
+        }
+    }
+}
+
 impl Subst for Term<Prd> {
     type Target = Term<Prd>;
     fn subst_sim(

--- a/lang/core_lang/src/syntax/terms/xtor.rs
+++ b/lang/core_lang/src/syntax/terms/xtor.rs
@@ -131,7 +131,7 @@ impl<C: Chi> Focusing for Xtor<C> {
 }
 
 impl Bind for Xtor<Prd> {
-    // bind(C(t_i))[k] = bind(t_i)[λas.⟨ C(as) | ~μx.k(x) ⟩]
+    // bind(K(t_i))[k] = bind(t_i)[λas.⟨ K(as) | ~μx.k(x) ⟩]
     fn bind(self, k: Continuation, max_id: &mut ID) -> FsStatement {
         bind_many(
             self.args.into(),

--- a/lang/core_lang/src/traits/focus.rs
+++ b/lang/core_lang/src/traits/focus.rs
@@ -42,7 +42,7 @@ impl<T: Focusing> Focusing for Vec<T> {
     }
 }
 
-/// This is a type alias for a meta-level continuation, which abstracts over a (co)variable
+/// This is a type alias for a meta-level continuation that abstracts over a (co)variable
 /// standing for a term in argument position that has been lifted out of a statement. When the
 /// continuation is applied to a (co)variable, it returns the focused statement with the
 /// (co)variable in the place of the term that was lifted. The continuation also expects the
@@ -57,7 +57,7 @@ pub type ContinuationVec = Box<dyn FnOnce(VecDeque<ContextBinding>, &mut ID) -> 
 pub trait Bind: Sized {
     /// This method is used during [focusing](Focusing) to avoid administrative redexes. It takes
     /// a term that has been lifted out of argument position and additionally a meta-level
-    /// [continuation](Continuation) which contains the statement from which the term has been
+    /// [continuation](Continuation) that contains the statement from which the term has been
     /// lifted. It eventually yields the focused statement.
     /// - `continuation` is the continuation containing the statement from which the term has been
     ///   lifted.
@@ -77,20 +77,7 @@ pub trait Bind: Sized {
 pub fn bind_many(mut args: VecDeque<Argument>, k: ContinuationVec, max_id: &mut ID) -> FsStatement {
     match args.pop_front() {
         None => k(VecDeque::new(), max_id),
-        Some(Argument::Producer(prd)) => prd.bind(
-            Box::new(|binding, max_id| {
-                bind_many(
-                    args,
-                    Box::new(|mut bindings, max_id| {
-                        bindings.push_front(binding);
-                        k(bindings, max_id)
-                    }),
-                    max_id,
-                )
-            }),
-            max_id,
-        ),
-        Some(Argument::Consumer(cns)) => cns.bind(
+        Some(arg) => arg.bind(
             Box::new(|binding, max_id| {
                 bind_many(
                     args,

--- a/lang/core_lang/src/traits/is_co_value.rs
+++ b/lang/core_lang/src/traits/is_co_value.rs
@@ -1,0 +1,25 @@
+use crate::syntax::CodataDeclaration;
+
+/// This trait provides a method for deciding whether a given term is a (co)value.
+pub trait IsCoValue {
+    /// This method returns whether the given term is a (co)value.
+    fn is_co_value(&self, codata_types: &[CodataDeclaration]) -> bool;
+}
+
+impl<T: IsCoValue> IsCoValue for Vec<T> {
+    fn is_co_value(&self, codata_types: &[CodataDeclaration]) -> bool {
+        self.iter().all(|element| element.is_co_value(codata_types))
+    }
+}
+
+/// This trait provides a method for deciding whether a given term is a value.
+pub trait IsValue {
+    /// This method returns whether the given term is a value.
+    fn is_value(&self, codata_types: &[CodataDeclaration]) -> bool;
+}
+
+/// This trait provides a method for deciding whether a given term is a covalue.
+pub trait IsCovalue {
+    /// This method returns whether the given term is a covalue.
+    fn is_covalue(&self, codata_types: &[CodataDeclaration]) -> bool;
+}

--- a/lang/core_lang/src/traits/mod.rs
+++ b/lang/core_lang/src/traits/mod.rs
@@ -2,12 +2,14 @@
 //! the [`Focusing`] trait for transforming a Core program into the focused fragment of Core.
 
 pub mod focus;
+pub mod is_co_value;
 pub mod substitution;
 pub mod typed;
 pub mod typed_free_vars;
 pub mod uniquify;
 
 pub use focus::{Bind, Continuation, Focusing, bind_many};
+pub use is_co_value::{IsCoValue, IsCovalue, IsValue};
 pub use substitution::{Subst, SubstVar};
 pub use typed::Typed;
 pub use typed_free_vars::TypedFreeVars;

--- a/lang/fun/src/syntax/context.rs
+++ b/lang/fun/src/syntax/context.rs
@@ -7,6 +7,7 @@ use printer::*;
 
 use crate::parser::util::ToMiette;
 use crate::syntax::*;
+use crate::traits::*;
 use crate::typing::*;
 
 use std::collections::{HashMap, HashSet};

--- a/lang/fun/src/syntax/mod.rs
+++ b/lang/fun/src/syntax/mod.rs
@@ -16,4 +16,4 @@ pub use context::{
 pub use declarations::*;
 pub use names::{Covar, Name, Var, fresh_covar};
 pub use terms::*;
-pub use types::{OptTyped, Ty, TypeArgs};
+pub use types::{Ty, TypeArgs};

--- a/lang/fun/src/syntax/terms/literal.rs
+++ b/lang/fun/src/syntax/terms/literal.rs
@@ -5,6 +5,7 @@ use miette::SourceSpan;
 use printer::*;
 
 use crate::syntax::*;
+use crate::traits::*;
 use crate::typing::*;
 
 /// This struct defines integer literals in Fun.

--- a/lang/fun/src/syntax/terms/mod.rs
+++ b/lang/fun/src/syntax/terms/mod.rs
@@ -38,14 +38,11 @@ use printer::Print;
 
 use crate::{
     syntax::names::Var,
-    traits::used_binders::UsedBinders,
+    traits::*,
     typing::{check::Check, errors::Error, symbol_table::SymbolTable},
 };
 
-use super::{
-    context::TypingContext,
-    types::{OptTyped, Ty},
-};
+use super::{context::TypingContext, types::Ty};
 
 use std::collections::HashSet;
 

--- a/lang/fun/src/syntax/terms/var.rs
+++ b/lang/fun/src/syntax/terms/var.rs
@@ -5,6 +5,7 @@ use miette::SourceSpan;
 use printer::*;
 
 use crate::syntax::*;
+use crate::traits::*;
 use crate::typing::*;
 
 /// This struct defines variables and covariables. It consists of the name of the (co)variable, and

--- a/lang/fun/src/syntax/types.rs
+++ b/lang/fun/src/syntax/types.rs
@@ -241,12 +241,6 @@ fn create_instance(
     Ok(())
 }
 
-/// This trait provides a fallible method to obtain the type of a term.
-pub trait OptTyped {
-    /// This method returns the type of a term if it is known.
-    fn get_type(&self) -> Option<Ty>;
-}
-
 impl Print for Ty {
     fn print<'a>(&'a self, cfg: &PrintCfg, alloc: &'a Alloc<'a>) -> Builder<'a> {
         match self {

--- a/lang/fun/src/traits/mod.rs
+++ b/lang/fun/src/traits/mod.rs
@@ -1,4 +1,6 @@
 //! This module defines infrastructure traits for the surface language Fun.
+pub mod opt_typed;
 pub mod used_binders;
 
+pub use opt_typed::OptTyped;
 pub use used_binders::UsedBinders;

--- a/lang/fun/src/traits/opt_typed.rs
+++ b/lang/fun/src/traits/opt_typed.rs
@@ -1,0 +1,7 @@
+use crate::syntax::Ty;
+
+/// This trait provides a fallible method to obtain the type of a term.
+pub trait OptTyped {
+    /// This method returns the type of a term if it is known.
+    fn get_type(&self) -> Option<Ty>;
+}

--- a/lang/fun/src/traits/used_binders.rs
+++ b/lang/fun/src/traits/used_binders.rs
@@ -5,7 +5,7 @@ use crate::syntax::names::Var;
 use std::collections::HashSet;
 use std::rc::Rc;
 
-/// This trait provides a method for for collecting the names of all binders used in a given term.
+/// This trait provides a method for collecting the names of all binders used in a given term.
 pub trait UsedBinders {
     /// This method collects the names of all binders used in a given term into a set.
     /// - `used` is the set into which the names are collected.

--- a/lang/fun2core/src/arguments.rs
+++ b/lang/fun2core/src/arguments.rs
@@ -5,7 +5,7 @@ use crate::{
     types::compile_ty,
 };
 use core_lang::syntax::{names::Identifier, terms::Cns};
-use fun::syntax::types::OptTyped;
+use fun::traits::OptTyped;
 
 /// This function translates [arguments in Fun](fun::syntax::arguments::Arguments) to
 /// [arguments in Core](core_lang::syntax::arguments::Arguments).

--- a/lang/fun2core/src/compile.rs
+++ b/lang/fun2core/src/compile.rs
@@ -5,13 +5,14 @@
 //! administrative redexes.
 
 use core_lang::syntax::{
-    CodataDeclaration, Def, Ty,
+    CodataDeclaration, Def, Statement, Ty,
+    arguments::Argument,
     context::Chirality,
     names::Identifier,
     statements::Cut,
-    terms::{Cns, Mu, Prd},
+    terms::{Cns, Mu, Prd, XVar},
 };
-use core_lang::traits::{Typed, TypedFreeVars};
+use core_lang::traits::{IsCoValue, Typed, TypedFreeVars};
 use fun::syntax::names::{Covar, Name, Var, fresh_covar, fresh_name, fresh_var};
 
 use std::{
@@ -188,4 +189,90 @@ pub fn share(
         ty,
     )
     .into()
+}
+
+/// This is a type alias for a meta-level continuation that abstracts over an argument that has
+/// been lifted out of a statement. When the continuation is applied to a term, it returns the
+/// statement with the term in the place of the argument that was lifted. The continuation also
+/// expects the current state of the translation.
+pub type Continuation = Box<dyn FnOnce(Argument, &mut CompileState) -> Statement>;
+/// This is a type alias for a meta-level continuation similar to [Continuation], but it abstracts
+/// over many arguments at once.
+pub type ContinuationVec = Box<dyn FnOnce(VecDeque<Argument>, &mut CompileState) -> Statement>;
+
+/// This function is used during the translation from [Fun](fun) into [Core](core_lang) to avoid
+/// administrative redexes in the destructor case. It takes a term that is to be lifted out of
+/// argument position if it is not a (co)value and additionally a meta-level
+/// [continuation](Continuation) that contains the statement from which the term is lifted. It
+/// eventually yields the resulting statement.
+/// - `continuation` is the continuation containing the statement from which the term has been
+///   lifted.
+/// - `state` is the [state](CompileState) threaded through the translation.
+fn bind(arg: Argument, k: Continuation, state: &mut CompileState) -> Statement {
+    if arg.is_co_value(state.codata_types) {
+        k(arg, state)
+    } else {
+        let ty = arg.get_type();
+        match arg {
+            Argument::Producer(prd) => {
+                let new_var = Identifier::new(state.fresh_var());
+                let new_binding = XVar::var(new_var.clone(), ty.clone());
+                Cut::new(
+                    prd,
+                    Mu::tilde_mu(
+                        new_var,
+                        k(Argument::Producer(new_binding.into()), state),
+                        ty.clone(),
+                    ),
+                    ty,
+                )
+                .into()
+            }
+            Argument::Consumer(cns) => {
+                let new_covar = Identifier::new(state.fresh_covar());
+                let new_binding = XVar::covar(new_covar.clone(), ty.clone());
+                Cut::new(
+                    Mu::mu(
+                        new_covar,
+                        k(Argument::Consumer(new_binding.into()), state),
+                        ty.clone(),
+                    ),
+                    cns,
+                    ty,
+                )
+                .into()
+            }
+        }
+    }
+}
+
+/// This function is used during the translation from [Fun](fun) into [Core](core_lang) to avoid
+/// administrative redexes in the destructor case. It is similar to the [`bind_co_value`]-function,
+/// but for a whole list of lifted terms.
+/// - `args` is the list of lifted terms.
+/// - `continuation` is the continuation containing the statement from which the terms have been
+///   lifted.
+/// - `state` is the [state](CompileState) threaded through the translation.
+pub fn bind_many(
+    mut args: VecDeque<Argument>,
+    k: ContinuationVec,
+    state: &mut CompileState,
+) -> Statement {
+    match args.pop_front() {
+        None => k(VecDeque::new(), state),
+        Some(arg) => bind(
+            arg,
+            Box::new(|binding, state| {
+                bind_many(
+                    args,
+                    Box::new(|mut bindings, state| {
+                        bindings.push_front(binding);
+                        k(bindings, state)
+                    }),
+                    state,
+                )
+            }),
+            state,
+        ),
+    }
 }

--- a/lang/fun2core/src/compile.rs
+++ b/lang/fun2core/src/compile.rs
@@ -247,8 +247,8 @@ fn bind(arg: Argument, k: Continuation, state: &mut CompileState) -> Statement {
 }
 
 /// This function is used during the translation from [Fun](fun) into [Core](core_lang) to avoid
-/// administrative redexes in the destructor case. It is similar to the [`bind_co_value`]-function,
-/// but for a whole list of lifted terms.
+/// administrative redexes in the destructor case. It is similar to the [`bind`]-function, but for
+/// a whole list of lifted terms.
 /// - `args` is the list of lifted terms.
 /// - `continuation` is the continuation containing the statement from which the terms have been
 ///   lifted.

--- a/lang/fun2core/src/def.rs
+++ b/lang/fun2core/src/def.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use core_lang::syntax::{CodataDeclaration, names::Identifier};
 use fun::{
-    syntax::{names::Name, types::OptTyped},
-    traits::used_binders::UsedBinders,
+    syntax::names::Name,
+    traits::{OptTyped, UsedBinders},
 };
 
 use std::collections::{HashSet, VecDeque};

--- a/lang/fun2core/src/terms/case.rs
+++ b/lang/fun2core/src/terms/case.rs
@@ -6,7 +6,7 @@ use crate::{
     types::compile_ty,
 };
 use core_lang::syntax::terms::Cns;
-use fun::syntax::types::OptTyped;
+use fun::traits::OptTyped;
 
 use std::rc::Rc;
 

--- a/lang/fun2core/src/terms/clause.rs
+++ b/lang/fun2core/src/terms/clause.rs
@@ -10,7 +10,7 @@ use core_lang::syntax::{
     names::Identifier,
     terms::{Cns, Prd},
 };
-use fun::syntax::types::OptTyped;
+use fun::traits::OptTyped;
 
 use std::rc::Rc;
 

--- a/lang/fun2core/src/terms/destructor.rs
+++ b/lang/fun2core/src/terms/destructor.rs
@@ -2,16 +2,16 @@
 
 use crate::{
     arguments::compile_subst,
-    compile::{Compile, CompileState},
+    compile::{Compile, CompileState, bind_many},
     types::compile_ty,
 };
 use core_lang::syntax::{names::Identifier, terms::Cns};
-use fun::syntax::types::OptTyped;
+use fun::traits::OptTyped;
 
 impl Compile for fun::syntax::terms::Destructor {
     /// This implementation of [Compile::compile_with_cont] proceeds as follows.
     /// ```text
-    /// 〚t.D(t_1, ...) 〛_{c} = 〚t〛_{D(〚t_1〛, ..., c)}
+    /// 〚t.D(t_1, ...) 〛_{c} = bind_many_v(〚t_1, ...〛)[λas.〚t〛_{D(as, c)}]
     /// ```
     ///
     /// # Panics
@@ -22,24 +22,30 @@ impl Compile for fun::syntax::terms::Destructor {
         cont: core_lang::syntax::terms::Term<Cns>,
         state: &mut CompileState,
     ) -> core_lang::syntax::Statement {
-        let mut args = compile_subst(self.args, state);
-        args.entries.push(cont.into());
-        // new continuation: D(〚t_1〛, ..., c)
-        let new_cont = core_lang::syntax::terms::Xtor {
-            prdcns: Cns,
-            name: Identifier::new(self.id),
-            args,
-            ty: compile_ty(
-                &self
-                    .scrutinee
-                    .get_type()
-                    .expect("Types should be annotated before translation"),
-            ),
-        }
-        .into();
+        bind_many(
+            // 〚t_1, ...〛
+            compile_subst(self.args, state).into(),
+            Box::new(|mut bindings, state| {
+                bindings.push_back(cont.into());
+                // new continuation: D(as, c)
+                let new_cont = core_lang::syntax::terms::Xtor {
+                    prdcns: Cns,
+                    name: Identifier::new(self.id),
+                    args: bindings.into(),
+                    ty: compile_ty(
+                        &self
+                            .scrutinee
+                            .get_type()
+                            .expect("Types should be annotated before translation"),
+                    ),
+                }
+                .into();
 
-        // 〚t〛_{new_cont}
-        self.scrutinee.compile_with_cont(new_cont, state)
+                // 〚t〛_{new_cont}
+                self.scrutinee.compile_with_cont(new_cont, state)
+            }),
+            state,
+        )
     }
 }
 


### PR DESCRIPTION
This fixes the translation from `Fun` to `Core` for destructor invocations by lifting the non-(co)value arguments out of the destructor. This way the destructor becomes a covalue, and can hence be safely inlined.